### PR TITLE
Removes payload rotation from request.

### DIFF
--- a/examples/boost_redis.cpp
+++ b/examples/boost_redis.cpp
@@ -4,11 +4,4 @@
  * accompanying file LICENSE.txt)
  */
 
-#include <boost/redis/config.hpp>
-#include <boost/redis/connection.hpp>
-#include <boost/redis/request.hpp>
-#include <boost/asio/detached.hpp>
-#include <boost/asio/deferred.hpp>
-#include <boost/asio/consign.hpp>
-
 #include <boost/redis/src.hpp>


### PR DESCRIPTION
The user can simply call HELLO before other commands. Altering the order of requests makes it impossible to declare responses.