### PR TITLE
build: add cmake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,15 @@ cmake_minimum_required(VERSION 3.14)
 
 #set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CMAKE_COMMAND} -E time")
 
+# determine whether it's main/root project
+# or being built under another project.
+if (NOT DEFINED BOOST_REDIS_MAIN_PROJECT)
+   set(BOOST_REDIS_MAIN_PROJECT OFF)
+   if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+      set(BOOST_REDIS_MAIN_PROJECT ON)
+   endif()
+endif()
+
 project(
     boost_redis
     VERSION 1.4.1
@@ -9,6 +18,12 @@ project(
     HOMEPAGE_URL "https://boostorg.github.io/redis/"
     LANGUAGES CXX
 )
+
+option(BOOST_REDIS_INSTALL "Generate install targets." ${BOOST_REDIS_MAIN_PROJECT})
+option(BOOST_REDIS_TESTS "Build tests." ${BOOST_REDIS_MAIN_PROJECT})
+option(BOOST_REDIS_EXAMPLES "Build examples." ${BOOST_REDIS_MAIN_PROJECT})
+option(BOOST_REDIS_BENCHMARKS "Build benchmarks." ${BOOST_REDIS_MAIN_PROJECT})
+option(BOOST_REDIS_DOC "Generate documentations." ${BOOST_REDIS_MAIN_PROJECT})
 
 add_library(boost_redis INTERFACE)
 add_library(Boost::redis ALIAS boost_redis)
@@ -34,185 +49,181 @@ target_compile_features(boost_redis INTERFACE cxx_std_17)
 # Asio bases C++ feature detection on __cplusplus. Make MSVC
 # define it correctly
 if (MSVC)
-    target_compile_options(boost_redis INTERFACE /Zc:__cplusplus)
+  target_compile_options(boost_redis INTERFACE /Zc:__cplusplus)
 endif()
-
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-    "${PROJECT_BINARY_DIR}/BoostRedisConfigVersion.cmake"
-    COMPATIBILITY AnyNewerVersion
-)
 
 find_package(Boost 1.80 REQUIRED)
-
-# We test the protobuf example only on gcc.
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-   find_package(Protobuf) # For the protobuf example.
-endif()
 
 include_directories(${Boost_INCLUDE_DIRS})
 
 find_package(OpenSSL REQUIRED)
 
-enable_testing()
 include_directories(include)
 
+# Common
 #=======================================================================
 
-set(libs_common boost_redis_src)
-set(libs_cpp17 tests_common)
-set(libs_cpp20 examples_main)
+add_library(boost_redis_project_options INTERFACE)
+target_link_libraries(boost_redis_project_options INTERFACE OpenSSL::Crypto OpenSSL::SSL)
+if (MSVC)
+   target_compile_options(boost_redis_project_options INTERFACE /bigobj)
+   target_compile_definitions(boost_redis_project_options INTERFACE _WIN32_WINNT=0x0601)
+endif()
 
-foreach(lib IN LISTS libs_cpp20 libs_cpp17 libs_common)
-   add_library(${lib} STATIC)
-endforeach()
-
-target_sources(boost_redis_src PRIVATE examples/boost_redis.cpp)
-target_sources(tests_common PRIVATE tests/common.cpp)
-target_sources(examples_main PRIVATE examples/main.cpp)
+add_library(boost_redis_src STATIC examples/boost_redis.cpp)
+target_compile_features(boost_redis_src PRIVATE cxx_std_17)
+target_link_libraries(boost_redis_src PRIVATE boost_redis_project_options)
 
 # Executables
 #=======================================================================
 
-set(benchmakrs echo_server_client echo_server_direct)
-add_executable(echo_server_client benchmarks/cpp/asio/echo_server_client.cpp)
-add_executable(echo_server_direct benchmarks/cpp/asio/echo_server_direct.cpp)
+if (BOOST_REDIS_BENCHMARKS)
+  add_library(benchmarks_options INTERFACE)
+  target_link_libraries(benchmarks_options INTERFACE boost_redis_src)
+  target_link_libraries(benchmarks_options INTERFACE boost_redis_project_options)
+  target_compile_features(benchmarks_options INTERFACE cxx_std_20)
 
-set(tests_cpp17
-   test_conn_quit
-   test_conn_tls
-   test_low_level
-   test_conn_exec_retry
-   test_conn_exec_error
-   test_request
-   test_run
-   test_low_level_sync
-   test_conn_check_health
-)
+  add_executable(echo_server_client benchmarks/cpp/asio/echo_server_client.cpp)
+  target_link_libraries(echo_server_client PRIVATE benchmarks_options)
 
-set(tests_cpp20
-    test_conn_exec
-    test_conn_push
-    test_conn_reconnect
-    test_conn_exec_cancel
-    test_conn_exec_cancel2
-    test_conn_echo_stress
-    test_low_level_async
-    test_conn_run_cancel
-    test_issue_50
-)
-
-set(examples_cpp17
-    cpp17_intro
-    cpp17_intro_sync)
-
-set(examples_cpp20
-    cpp20_intro
-    cpp20_streams
-    cpp20_containers
-    cpp20_echo_server
-    cpp20_json
-    cpp20_subscriber
-    cpp20_intro_tls
-    cpp20_resolve_with_sentinel
-)
-
-if (Protobuf_FOUND)
-   list(APPEND examples_cpp20 cpp20_protobuf)
+  add_executable(echo_server_direct benchmarks/cpp/asio/echo_server_direct.cpp)
+  target_link_libraries(echo_server_direct PRIVATE benchmarks_options)
 endif()
 
-if (NOT MSVC)
-   list(APPEND examples_cpp20 cpp20_chat_room)
+if (BOOST_REDIS_EXAMPLES)
+  add_library(examples_main STATIC examples/main.cpp)
+  target_compile_features(examples_main PRIVATE cxx_std_20)
+  target_link_libraries(examples_main PRIVATE boost_redis_project_options)
+
+  macro(make_example EXAMPLE_NAME STANDARD)
+    add_executable(${EXAMPLE_NAME} examples/${EXAMPLE_NAME}.cpp)
+    target_link_libraries(${EXAMPLE_NAME} PRIVATE boost_redis_src)
+    target_link_libraries(${EXAMPLE_NAME} PRIVATE boost_redis_project_options)
+    target_compile_features(${EXAMPLE_NAME} PRIVATE cxx_std_${STANDARD})
+    if (${STANDARD} STREQUAL "20")
+      target_link_libraries(${EXAMPLE_NAME} PRIVATE examples_main)
+    endif()
+  endmacro()
+
+  macro(make_testable_example EXAMPLE_NAME STANDARD)
+    make_example(${EXAMPLE_NAME} ${STANDARD})
+    add_test(${EXAMPLE_NAME} ${EXAMPLE_NAME})
+  endmacro()
+
+  make_testable_example(cpp17_intro 17)
+  make_testable_example(cpp17_intro_sync 17)
+
+  make_testable_example(cpp20_intro 20)
+  make_testable_example(cpp20_containers 20)
+  make_testable_example(cpp20_json 20)
+  make_testable_example(cpp20_intro_tls 20)
+
+  make_example(cpp20_subscriber 20)
+  make_example(cpp20_streams 20)
+  make_example(cpp20_echo_server 20)
+  make_example(cpp20_resolve_with_sentinel 20)
+
+  # We test the protobuf example only on gcc.
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    find_package(Protobuf)
+    if (Protobuf_FOUND)
+       protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS examples/person.proto)
+       make_testable_example(cpp20_protobuf 20)
+       target_sources(cpp20_protobuf PUBLIC ${PROTO_SRCS} ${PROTO_HDRS})
+       target_link_libraries(cpp20_protobuf PRIVATE  ${Protobuf_LIBRARIES})
+       target_include_directories(cpp20_protobuf PUBLIC ${Protobuf_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR})
+    endif()
+  endif()
+
+  if (NOT MSVC)
+     make_example(cpp20_chat_room 20)
+  endif()
 endif()
 
-foreach(exe IN LISTS examples_cpp17 examples_cpp20)
-   add_executable(${exe} examples/${exe}.cpp)
-endforeach()
+if (BOOST_REDIS_TESTS)
+  enable_testing()
 
-foreach(exe IN LISTS examples_cpp20)
-   target_link_libraries(${exe} PRIVATE examples_main)
-endforeach()
+  add_library(tests_common STATIC tests/common.cpp)
+  target_compile_features(tests_common PRIVATE cxx_std_17)
+  target_link_libraries(tests_common PRIVATE boost_redis_project_options)
 
-foreach(exe IN LISTS tests_cpp17 tests_cpp20)
-   add_executable(${exe} tests/${exe}.cpp)
-   target_link_libraries(${exe} PRIVATE  tests_common)
-endforeach()
+  macro(make_test TEST_NAME STANDARD)
+    add_executable(${TEST_NAME} tests/${TEST_NAME}.cpp)
+    target_link_libraries(${TEST_NAME} PRIVATE boost_redis_src tests_common)
+    target_link_libraries(${TEST_NAME} PRIVATE boost_redis_project_options)
+    target_compile_features(${TEST_NAME} PRIVATE cxx_std_${STANDARD})
+    add_test(${TEST_NAME} ${TEST_NAME})
+  endmacro()
 
-foreach(exe IN LISTS tests_cpp17 tests_cpp20 examples_cpp17 examples_cpp20 libs_cpp17 libs_cpp20 libs_common benchmakrs)
-   target_link_libraries(${exe} PRIVATE OpenSSL::Crypto OpenSSL::SSL)
-   if (MSVC)
-      target_compile_options(${exe} PRIVATE /bigobj)
-      target_compile_definitions(${exe} PRIVATE _WIN32_WINNT=0x0601)
-   endif()
-endforeach()
+  make_test(test_conn_quit 17)
+  make_test(test_conn_tls 17)
+  make_test(test_low_level 17)
+  make_test(test_conn_exec_retry 17)
+  make_test(test_conn_exec_error 17)
+  make_test(test_request 17)
+  make_test(test_run 17)
+  make_test(test_low_level_sync 17)
+  make_test(test_conn_check_health 17)
 
-foreach(exe IN LISTS tests_cpp17 tests_cpp20 examples_cpp17 examples_cpp20 libs_cpp17 libs_cpp20 benchmakrs)
-   target_link_libraries(${exe} PRIVATE boost_redis_src)
-endforeach()
-
-foreach(exe IN LISTS tests_cpp20 examples_cpp20 libs_cpp20 benchmarks)
-   target_compile_features(${exe} PUBLIC cxx_std_20)
-endforeach()
-
-foreach(exe IN LISTS tests_cpp17 examples_cpp17 libs_cpp17 libs_common)
-   target_compile_features(${exe} PUBLIC cxx_std_17)
-endforeach()
-
-if (Protobuf_FOUND)
-   protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS examples/person.proto)
-   target_sources(cpp20_protobuf PUBLIC ${PROTO_SRCS} ${PROTO_HDRS})
-   target_link_libraries(cpp20_protobuf PRIVATE  ${Protobuf_LIBRARIES})
-   target_include_directories(cpp20_protobuf PUBLIC ${Protobuf_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR})
-   add_test(cpp20_protobuf cpp20_protobuf)
+  make_test(test_conn_exec 20)
+  make_test(test_conn_push 20)
+  make_test(test_conn_reconnect 20)
+  make_test(test_conn_exec_cancel 20)
+  make_test(test_conn_exec_cancel2 20)
+  make_test(test_conn_echo_stress 20)
+  make_test(test_low_level_async 20)
+  make_test(test_conn_run_cancel 20)
+  make_test(test_issue_50 20)
 endif()
-
-add_test(cpp17_intro cpp17_intro)
-add_test(cpp17_intro_sync cpp17_intro_sync)
-add_test(cpp20_intro cpp20_intro)
-add_test(cpp20_containers cpp20_containers)
-add_test(cpp20_json cpp20_json)
-add_test(cpp20_intro_tls cpp20_intro_tls)
-
-foreach(exe IN LISTS tests_cpp17 tests_cpp20)
-   add_test(${exe} ${exe})
-endforeach()
 
 # Install
 #=======================================================================
 
-install(TARGETS boost_redis
-    EXPORT boost_redis
-    PUBLIC_HEADER DESTINATION include COMPONENT Development
-)
+if (BOOST_REDIS_INSTALL)
+  install(TARGETS boost_redis
+      EXPORT boost_redis
+      PUBLIC_HEADER DESTINATION include COMPONENT Development
+  )
+  
+  include(CMakePackageConfigHelpers)
+  
+  configure_package_config_file(
+     "${PROJECT_SOURCE_DIR}/cmake/BoostRedisConfig.cmake.in"
+     "${PROJECT_BINARY_DIR}/BoostRedisConfig.cmake"
+      INSTALL_DESTINATION lib/cmake/boost/redis
+  )
+  
+  install(EXPORT boost_redis DESTINATION lib/cmake/boost/redis)
+  install(FILES "${PROJECT_BINARY_DIR}/BoostRedisConfigVersion.cmake"
+     "${PROJECT_BINARY_DIR}/BoostRedisConfig.cmake"
+       DESTINATION lib/cmake/boost/redis)
+  
+  install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/ DESTINATION include)
 
-include(CMakePackageConfigHelpers)
+  include(CMakePackageConfigHelpers)
+  write_basic_package_version_file(
+    "${PROJECT_BINARY_DIR}/BoostRedisConfigVersion.cmake"
+    COMPATIBILITY AnyNewerVersion
+  )
 
-configure_package_config_file(
-   "${PROJECT_SOURCE_DIR}/cmake/BoostRedisConfig.cmake.in"
-   "${PROJECT_BINARY_DIR}/BoostRedisConfig.cmake"
-    INSTALL_DESTINATION lib/cmake/boost/redis
-)
-
-install(EXPORT boost_redis DESTINATION lib/cmake/boost/redis)
-install(FILES "${PROJECT_BINARY_DIR}/BoostRedisConfigVersion.cmake"
-   "${PROJECT_BINARY_DIR}/BoostRedisConfig.cmake"
-     DESTINATION lib/cmake/boost/redis)
-
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/ DESTINATION include)
+  include(CPack)
+endif()
 
 # Doxygen
 #=======================================================================
 
-set(DOXYGEN_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/doc")
-configure_file(doc/Doxyfile.in doc/Doxyfile @ONLY)
-
-add_custom_target(
-    doc
-    COMMAND doxygen "${PROJECT_BINARY_DIR}/doc/Doxyfile"
-    COMMENT "Building documentation using Doxygen"
-    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-    VERBATIM
-)
+if (BOOST_REDIS_DOC)
+  set(DOXYGEN_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/doc")
+  configure_file(doc/Doxyfile.in doc/Doxyfile @ONLY)
+  
+  add_custom_target(
+      doc
+      COMMAND doxygen "${PROJECT_BINARY_DIR}/doc/Doxyfile"
+      COMMENT "Building documentation using Doxygen"
+      WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+      VERBATIM
+  )
+endif()
 
 # Coverage
 #=======================================================================
@@ -240,11 +251,6 @@ add_custom_target(
     COMMENT "Generating coverage report"
     VERBATIM
 )
-
-# Distribution
-#=======================================================================
-
-include(CPack)
 
 # TODO
 #=======================================================================


### PR DESCRIPTION
Added cmake options for install, tests, examples, and doc instead of always building them.

options are enabled by default when building the project directly, otherwise if add_subdirectory (directly or by FetchContent, etc), then unnecessary options will be disabled.

This PR is related to #115 issue.