### PR TITLE
connection: async_exec forwards completion token

### DIFF
--- a/include/boost/redis/connection.hpp
+++ b/include/boost/redis/connection.hpp
@@ -227,9 +227,9 @@ public:
    async_exec(
       request const& req,
       Response& resp = ignore,
-      CompletionToken token = CompletionToken{})
+      CompletionToken&& token = CompletionToken{})
    {
-      return impl_.async_exec(req, resp, token);
+      return impl_.async_exec(req, resp, std::forward<CompletionToken>(token));
    }
 
    /** @brief Cancel operations.


### PR DESCRIPTION
async operations should support move-only completion handlers. forward the CompletionToken argument to avoid an unnecessary copy

Fixes: #131