### PR TITLE
Fix cmake find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 
 project(
     boost_redis
-    VERSION 1.4.1
+    VERSION 1.4.2
     DESCRIPTION "A redis client library"
     HOMEPAGE_URL "https://boostorg.github.io/redis/"
     LANGUAGES CXX

--- a/cmake/BoostRedisConfig.cmake.in
+++ b/cmake/BoostRedisConfig.cmake.in
@@ -1,4 +1,4 @@
 @PACKAGE_INIT@
 
-include("${CMAKE_CURRENT_LIST_DIR}/Aedis.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@.cmake")
 check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
`Aedis.cmake` was renamed at some point to `boost_redis.cmake`