### PR TITLE
Fixed CSS formatting for Boost docs

### DIFF
--- a/doc/Jamfile
+++ b/doc/Jamfile
@@ -12,6 +12,8 @@ path-constant include_dir : ../include ;
 path-constant examples_dir : ../example ;
 path-constant readme : ../README.md ;
 path-constant layout_file : DoxygenLayout.xml ;
+path-constant header : header.html ;
+path-constant footer : footer.html ;
 
 local stylesheet_files = [ path.glob $(this_dir) : *.css ] ;
 local includes = [ path.glob-tree $(include_dir) : *.hpp *.cpp ] ;
@@ -46,10 +48,13 @@ doxygen doc.html
         <doxygen:param>EXCLUDE_SYMBOLS=std
         <doxygen:param>"USE_MDFILE_AS_MAINPAGE=\"$(readme)\""
         <doxygen:param>SOURCE_BROWSER=YES
+        <doxygen:param>"HTML_HEADER=\"$(header)\""
+        <doxygen:param>"HTML_FOOTER=\"$(footer)\""
         <doxygen:param>"HTML_EXTRA_STYLESHEET=$(stylesheet_arg)"
         <doxygen:param>HTML_TIMESTAMP=YES
         <doxygen:param>GENERATE_TREEVIEW=YES
-        <doxygen:param>FULL_SIDEBAR=NO
+        <doxygen:param>FULL_SIDEBAR=YES
+        <doxygen:param>DISABLE_INDEX=YES
         <doxygen:param>ENUM_VALUES_PER_LINE=0
         <doxygen:param>OBFUSCATE_EMAILS=YES
         <doxygen:param>USE_MATHJAX=YES

--- a/doc/doxygen-awesome-sidebar-only.css
+++ b/doc/doxygen-awesome-sidebar-only.css
@@ -32,84 +32,112 @@ html {
      * Make sure it is wide enough to contain the page title (logo + title + version)
      */
     --side-nav-fixed-width: 335px;
-    --menu-display: none;
-
-    --top-height: 120px;
-    --toc-sticky-top: -25px;
-    --toc-max-height: calc(100vh - 2 * var(--spacing-medium) - 25px);
 }
 
 #projectname {
     white-space: nowrap;
 }
 
+#page-wrapper {
+    height: calc(100vh - 100px);
+}
 
-@media screen and (min-width: 768px) {
+#content-wrapper {
+    display: flex;
+    flex-direction: row;
+    min-height: 0;
+}
+
+#doc-content {
+    overflow-y: scroll;
+    flex: 1;
+    height: auto !important;
+}
+
+@media (min-width: 768px) {
     html {
         --searchbar-background: var(--page-background-color);
     }
 
-    #side-nav {
+    #sidebar-wrapper {
+        display: flex;
+        flex-direction: column;
         min-width: var(--side-nav-fixed-width);
-        max-width: var(--side-nav-fixed-width);
-        top: var(--top-height);
-        overflow: visible;
+        max-width: var(--side-nav-fixed-width);   
+        background-color: var(--side-nav-background);
+        border-right: 1px solid rgb(222, 222, 222);
     }
 
-    #nav-tree, #side-nav {
-        height: calc(100vh - var(--top-height)) !important;
+    #search-box-wrapper {
+        display: flex;
+        flex-direction: row;
+        padding-left: 1em;
+        padding-right: 1em;
+    }
+
+    #MSearchBox {
+        flex: 1;
+        display: flex;
+        padding-left: 1em;
+        padding-right: 1em;
+    }
+
+
+    #MSearchBox .left {
+        display: flex;
+        flex: 1;
+        position: static;
+        align-items: center;
+        justify-content: flex-start;
+        width: auto;
+        height: auto;
+    }
+
+    #MSearchBox .right {
+        display: none;
+    }
+
+    #MSearchSelect {
+        padding-left: 0.75em;
+        left: auto;
+    }
+
+    #MSearchField {
+        flex: 1;
+        position: static;
+        width: auto;
+        height: auto;
     }
 
     #nav-tree {
-        padding: 0;
+        height: auto !important;
+    }
+
+    #nav-sync {
+        display: none;
     }
 
     #top {
         display: block;
         border-bottom: none;
-        height: var(--top-height);
-        margin-bottom: calc(0px - var(--top-height));
         max-width: var(--side-nav-fixed-width);
         overflow: hidden;
         background: var(--side-nav-background);
-    }
-    #main-nav {
-        float: left;
-        padding-right: 0;
     }
 
     .ui-resizable-handle {
         cursor: default;
         width: 1px !important;
-        box-shadow: 0 calc(-2 * var(--top-height)) 0 0 var(--separator-color);
-    }
-
-    #nav-path {
-        position: fixed;
-        right: 0;
-        left: var(--side-nav-fixed-width);
-        bottom: 0;
-        width: auto;
-    }
-
-    #doc-content {
-        height: calc(100vh - 31px) !important;
-        padding-bottom: calc(3 * var(--spacing-large));
-        padding-top: calc(var(--top-height) - 80px);
-        box-sizing: border-box;
-        margin-left: var(--side-nav-fixed-width) !important;
-    }
-
-    #MSearchBox {
-        width: calc(var(--side-nav-fixed-width) - calc(2 * var(--spacing-medium)));
-    }
-
-    #MSearchField {
-        width: calc(var(--side-nav-fixed-width) - calc(2 * var(--spacing-medium)) - 65px);
     }
 
     #MSearchResultsWindow {
         left: var(--spacing-medium) !important;
         right: auto;
+    }
+}
+
+@media (max-width: 768px) {
+    #sidebar-wrapper {
+        display: none;
     }
 }

--- a/doc/doxygen-awesome.css
+++ b/doc/doxygen-awesome.css
@@ -552,25 +552,6 @@ a.anchor {
     margin-top: 0;
 }
 
-/* until Doxygen 1.9.4 */
-.left img#MSearchSelect {
-    left: 0;
-    user-select: none;
-    padding-left: 8px;
-}
-
-/* Doxygen 1.9.5 */
-.left span#MSearchSelect {
-    left: 0;
-    user-select: none;
-    margin-left: 8px;
-    padding: 0;
-}
-
-.left #MSearchSelect[src$=".png"] {
-    padding-left: 0
-}
-
 .SelectionMark {
     user-select: none;
 }
@@ -614,9 +595,7 @@ a.anchor {
 
 #MSearchField {
     font-size: var(--navigation-font-size);
-    height: calc(var(--searchbar-height) - 2px);
     background: transparent;
-    width: calc(var(--searchbar-width) - 64px);
 }
 
 .MSearchBoxActive #MSearchField {

--- a/doc/footer.html
+++ b/doc/footer.html
@@ -1,0 +1,19 @@
+<!-- HTML footer for doxygen 1.9.1-->
+<!-- start footer part -->
+</div> <!-- close #content-wrapper -->
+<!--BEGIN GENERATE_TREEVIEW-->
+<div id="nav-path" class="navpath"><!-- id is needed for treeview function! -->
+  <ul>
+    $navpath
+    <li class="footer">$generatedby <a href="https://www.doxygen.org/index.html"><img class="footer" src="$relpath^doxygen.svg" width="104" height="31" alt="doxygen"/></a> $doxygenversion </li>
+  </ul>
+</div>
+<!--END GENERATE_TREEVIEW-->
+<!--BEGIN !GENERATE_TREEVIEW-->
+<hr class="footer"/><address class="footer"><small>
+$generatedby&#160;<a href="https://www.doxygen.org/index.html"><img class="footer" src="$relpath^doxygen.svg" width="104" height="31" alt="doxygen"/></a> $doxygenversion
+</small></address>
+<!--END !GENERATE_TREEVIEW-->
+</div> <!-- #page-wrapper -->
+</body>
+</html>

--- a/doc/header.html
+++ b/doc/header.html
@@ -1,0 +1,61 @@
+<!-- HTML header for doxygen 1.9.1-->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>
+<meta http-equiv="X-UA-Compatible" content="IE=9"/>
+<meta name="generator" content="Doxygen $doxygenversion"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->
+<!--BEGIN !PROJECT_NAME--><title>$title</title><!--END !PROJECT_NAME-->
+<link href="$relpath^tabs.css" rel="stylesheet" type="text/css"/>
+<script type="text/javascript" src="$relpath^jquery.js"></script>
+<script type="text/javascript" src="$relpath^dynsections.js"></script>
+$treeview
+$search
+$mathjax
+<link href="$relpath^$stylesheet" rel="stylesheet" type="text/css" />
+$extrastylesheet
+</head>
+<body>
+<div id="page-wrapper">
+<div id="content-wrapper" style="display: flex; flex-direction: row">
+    <div id="sidebar-wrapper" style="display: flex; flex-direction: column">
+        <div id="top"><!-- do not remove this div, it is closed by doxygen! -->
+
+<!--BEGIN TITLEAREA-->
+            <div id="titlearea">
+                <table cellspacing="0" cellpadding="0">
+                    <tbody>
+                    <tr style="height: 56px;">
+                    <!--BEGIN PROJECT_LOGO-->
+                    <td id="projectlogo"><img alt="Logo" src="$relpath^$projectlogo"/></td>
+                    <!--END PROJECT_LOGO-->
+                    <!--BEGIN PROJECT_NAME-->
+                    <td id="projectalign" style="padding-left: 0.5em;">
+                    <div id="projectname">$projectname
+                    <!--BEGIN PROJECT_NUMBER-->&#160;<span id="projectnumber">$projectnumber</span><!--END PROJECT_NUMBER-->
+                    </div>
+                    <!--BEGIN PROJECT_BRIEF--><div id="projectbrief">$projectbrief</div><!--END PROJECT_BRIEF-->
+                    </td>
+                    <!--END PROJECT_NAME-->
+                    <!--BEGIN !PROJECT_NAME-->
+                    <!--BEGIN PROJECT_BRIEF-->
+                        <td style="padding-left: 0.5em;">
+                        <div id="projectbrief">$projectbrief</div>
+                        </td>
+                    <!--END PROJECT_BRIEF-->
+                    <!--END !PROJECT_NAME-->
+                    <!--BEGIN DISABLE_INDEX-->
+                    <!--END DISABLE_INDEX-->
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+            <!--BEGIN SEARCHENGINE-->
+            <div id="search-box-wrapper">
+                $searchbox
+            </div>
+            <!--END SEARCHENGINE-->
+<!--END TITLEAREA-->
+<!-- end header part -->


### PR DESCRIPTION
This should fix the Boost docs formatting problems. Tested locally with a fixed-width header, like the Boost one. I can't test locally with the exact header, so we might have to double check whether this fixed the problem correctly tomorrow.

close #158