### PR TITLE
Improves reconnection responsiveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,14 @@ https://lists.boost.org/Archives/boost/2023/01/253944.php.
 
 ## Changelog
 
+### Boost 1.87
+
+* ([Issue 205](https://github.com/boostorg/redis/issues/205))
+  Improves reaction time to disconnection by using `wait_for_one_error`
+  instead of `wait_for_all`. The function `connection::async_run` was
+  also changed to return EOF to the user when that error is received
+  from the server. That is a breaking change.
+
 ### Boost 1.85
 
 * ([Issue 170](https://github.com/boostorg/redis/issues/170))

--- a/include/boost/redis/detail/connection_base.hpp
+++ b/include/boost/redis/detail/connection_base.hpp
@@ -317,7 +317,7 @@ struct reader_op {
             if (ec == asio::error::eof) {
                logger_.trace("reader-op: EOF received. Exiting ...");
                conn_->cancel(operation::run);
-               return self.complete({}); // EOFINAE: EOF is not an error.
+               return self.complete(ec);
             }
 
             // The connection is not viable after an error.

--- a/include/boost/redis/detail/runner.hpp
+++ b/include/boost/redis/detail/runner.hpp
@@ -93,7 +93,7 @@ public:
             [this](auto token) { return runner_->health_checker_.async_check_health(*conn_, logger_, token); },
             [this](auto token) { return runner_->async_hello(*conn_, logger_, token); }
          ).async_wait(
-            asio::experimental::wait_for_all(),
+            asio::experimental::wait_for_one_error(),
             std::move(self));
 
          logger_.on_runner(ec0, ec1, ec2);

--- a/test/test_conn_exec.cpp
+++ b/test/test_conn_exec.cpp
@@ -152,6 +152,9 @@ BOOST_AUTO_TEST_CASE(correct_database)
    auto const pos = value.find("db=");
    auto const index_str = value.substr(pos + 3, 1);
    auto const index = std::stoi(index_str);
+
+   // This check might fail if more than one client is connected to
+   // redis when the CLIENT LIST command is run. 
    BOOST_CHECK_EQUAL(cfg.database_index.value(), index);
 }
 


### PR DESCRIPTION
As the user points out in

- https://github.com/boostorg/redis/issues/205

`wait_for_all` might be the cause of delay in the reconnection. I could not observe any improvement in my local setup but `wait_for_one_error` look the correct token and all tests pass so I am willing to change it.