### PR TITLE
Enables -Wall and -Werror in CIs

### DIFF
--- a/benchmarks/cpp/asio/echo_server_client.cpp
+++ b/benchmarks/cpp/asio/echo_server_client.cpp
@@ -27,9 +27,9 @@ auto example(boost::asio::ip::tcp::endpoint ep, std::string msg, int n) -> net::
       auto dbuffer = net::dynamic_buffer(buffer);
       for (int i = 0; i < n; ++i) {
          co_await net::async_write(socket, net::buffer(msg));
-         auto n = co_await net::async_read_until(socket, dbuffer, "\n");
+         auto bytes_read = co_await net::async_read_until(socket, dbuffer, "\n");
          //std::printf("> %s", buffer.data());
-         dbuffer.consume(n);
+         dbuffer.consume(bytes_read);
       }
 
       //std::printf("Ok: %s", msg.data());

--- a/include/boost/redis/adapter/detail/adapters.hpp
+++ b/include/boost/redis/adapter/detail/adapters.hpp
@@ -66,7 +66,7 @@ struct converter<T, true> {
 template <>
 struct converter<bool, false> {
    template <class String>
-   static void apply(bool& t, resp3::basic_node<String> const& node, system::error_code& ec)
+   static void apply(bool& t, resp3::basic_node<String> const& node, system::error_code&)
    {
       t = *node.value.data() == 't';
    }

--- a/include/boost/redis/connection.hpp
+++ b/include/boost/redis/connection.hpp
@@ -354,7 +354,7 @@ public:
       system::error_code ec1 = {},
       system::error_code ec2 = {},
       system::error_code ec3 = {},
-      system::error_code ec4 = {})
+      system::error_code = {})
    {
       BOOST_ASIO_CORO_REENTER(coro_) for (;;)
       {

--- a/include/boost/redis/resp3/impl/parser.ipp
+++ b/include/boost/redis/resp3/impl/parser.ipp
@@ -10,6 +10,7 @@
 #include <boost/assert.hpp>
 
 #include <charconv>
+#include <cstddef>
 #include <limits>
 
 namespace boost::redis::resp3 {
@@ -177,7 +178,7 @@ auto parser::consume_impl(type t, std::string_view elem, system::error_code& ec)
       case type::attribute:
       case type::map:
       {
-         std::size_t l = -1;
+         std::size_t l = static_cast<std::size_t>(-1);
          to_int(l, elem, ec);
          if (ec)
             return {};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,8 @@ target_link_libraries(boost_redis_project_options INTERFACE boost_redis)
 if (MSVC)
   target_compile_options(boost_redis_project_options INTERFACE /bigobj)
   target_compile_definitions(boost_redis_project_options INTERFACE _WIN32_WINNT=0x0601)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  target_compile_options(boost_redis_project_options INTERFACE -Wall -Wextra -Werror)
 endif()
 
 add_library(boost_redis_src STATIC boost_redis.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,8 @@
 add_library(boost_redis_project_options INTERFACE)
 target_link_libraries(boost_redis_project_options INTERFACE boost_redis)
 if (MSVC)
-  target_compile_options(boost_redis_project_options INTERFACE /bigobj /W4 /WX)
+  # C4459: name hides outer scope variable is issued by Asio
+  target_compile_options(boost_redis_project_options INTERFACE /bigobj /W4 /WX /wd4459)
   target_compile_definitions(boost_redis_project_options INTERFACE _WIN32_WINNT=0x0601)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   target_compile_options(boost_redis_project_options INTERFACE -Wall -Wextra -Werror)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,7 @@
 add_library(boost_redis_project_options INTERFACE)
 target_link_libraries(boost_redis_project_options INTERFACE boost_redis)
 if (MSVC)
-  target_compile_options(boost_redis_project_options INTERFACE /bigobj)
+  target_compile_options(boost_redis_project_options INTERFACE /bigobj /W4 /WX)
   target_compile_definitions(boost_redis_project_options INTERFACE _WIN32_WINNT=0x0601)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   target_compile_options(boost_redis_project_options INTERFACE -Wall -Wextra -Werror)

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -31,7 +31,7 @@ local requirements =
         ]
         [ ac.check-library /openssl//ssl    : <library>/openssl//ssl/<link>shared : <build>no ]
         [ ac.check-library /openssl//crypto : <library>/openssl//crypto/<link>shared : <build>no ]
-        <library>/boost/test//boost_unit_test_framework
+        <library>/boost/test//boost_unit_test_framework/<warnings-as-errors>off
     ;
 
 

--- a/test/test_conversions.cpp
+++ b/test/test_conversions.cpp
@@ -57,15 +57,15 @@ BOOST_AUTO_TEST_CASE(ints)
 
    // Check
    BOOST_TEST(std::get<1>(resp).value() == 42);
-   BOOST_TEST(std::get<2>(resp).value() == 42);
+   BOOST_TEST(std::get<2>(resp).value() == 42u);
    BOOST_TEST(std::get<3>(resp).value() == 42);
-   BOOST_TEST(std::get<4>(resp).value() == 42);
+   BOOST_TEST(std::get<4>(resp).value() == 42u);
    BOOST_TEST(std::get<5>(resp).value() == 42);
-   BOOST_TEST(std::get<6>(resp).value() == 42);
+   BOOST_TEST(std::get<6>(resp).value() == 42u);
    BOOST_TEST(std::get<7>(resp).value() == 42);
-   BOOST_TEST(std::get<8>(resp).value() == 42);
+   BOOST_TEST(std::get<8>(resp).value() == 42u);
    BOOST_TEST(std::get<9>(resp).value() == 42);
-   BOOST_TEST(std::get<10>(resp).value() == 42);
+   BOOST_TEST(std::get<10>(resp).value() == 42u);
 }
 
 BOOST_AUTO_TEST_CASE(bools)

--- a/test/test_issue_50.cpp
+++ b/test/test_issue_50.cpp
@@ -102,7 +102,7 @@ auto co_main(config) -> net::awaitable<void>
 BOOST_AUTO_TEST_CASE(issue_50)
 {
    net::io_context ioc;
-   net::co_spawn(ioc, std::move(co_main({})), net::detached);
+   net::co_spawn(ioc, co_main({}), net::detached);
    ioc.run();
 }
 

--- a/test/test_low_level.cpp
+++ b/test/test_low_level.cpp
@@ -9,10 +9,9 @@
 #include <boost/redis/resp3/parser.hpp>
 #include <boost/redis/response.hpp>
 
-#define BOOST_TEST_MODULE low level
+#define BOOST_TEST_MODULE low_level
 #include <boost/test/included/unit_test.hpp>
 
-#include <iostream>
 #include <map>
 #include <optional>
 #include <sstream>

--- a/test/test_low_level.cpp
+++ b/test/test_low_level.cpp
@@ -143,8 +143,6 @@ auto make_blob()
    str[1000] = '\r';
    str[1001] = '\n';
    return str;
-
-   return str;
 }
 
 auto const blob = make_blob();

--- a/test/test_low_level.cpp
+++ b/test/test_low_level.cpp
@@ -4,26 +4,25 @@
  * accompanying file LICENSE.txt)
  */
 
-#include <boost/redis/request.hpp>
-#include <boost/redis/response.hpp>
 #include <boost/redis/adapter/adapt.hpp>
+#include <boost/redis/request.hpp>
 #include <boost/redis/resp3/parser.hpp>
+#include <boost/redis/response.hpp>
 
 #define BOOST_TEST_MODULE low level
 #include <boost/test/included/unit_test.hpp>
 
-#include <map>
 #include <iostream>
+#include <map>
 #include <optional>
 #include <sstream>
 
 // TODO: Test with empty strings.
 
-namespace std
-{
-auto operator==(boost::redis::ignore_t, boost::redis::ignore_t) noexcept {return true;}
-auto operator!=(boost::redis::ignore_t, boost::redis::ignore_t) noexcept {return false;}
-}
+namespace std {
+auto operator==(boost::redis::ignore_t, boost::redis::ignore_t) noexcept { return true; }
+auto operator!=(boost::redis::ignore_t, boost::redis::ignore_t) noexcept { return false; }
+}  // namespace std
 
 namespace redis = boost::redis;
 namespace resp3 = boost::redis::resp3;
@@ -56,12 +55,20 @@ using array_type = result<std::array<int, 3>>;
 using array_type2 = result<std::array<int, 1>>;
 
 // Map
-using map_type =    result<std::map<std::string, std::string>>;
-using mmap_type =   result<std::multimap<std::string, std::string>>;
-using umap_type =   result<std::unordered_map<std::string, std::string>>;
-using mumap_type =  result<std::unordered_multimap<std::string, std::string>>;
+using map_type = result<std::map<std::string, std::string>>;
+using mmap_type = result<std::multimap<std::string, std::string>>;
+using umap_type = result<std::unordered_map<std::string, std::string>>;
+using mumap_type = result<std::unordered_multimap<std::string, std::string>>;
 using op_map_type = result<std::optional<std::map<std::string, std::string>>>;
-using tuple8_type = result<response<std::string, std::string, std::string, std::string, std::string, std::string, std::string, std::string>>;
+using tuple8_type = result<response<
+   std::string,
+   std::string,
+   std::string,
+   std::string,
+   std::string,
+   std::string,
+   std::string,
+   std::string>>;
 
 // Null
 using op_type_01 = result<std::optional<bool>>;
@@ -85,7 +92,11 @@ struct expect {
 };
 
 template <class Result>
-auto make_expected(std::string in, Result expected, error_code ec = {}, resp3::type error_type = resp3::type::invalid)
+auto make_expected(
+   std::string in,
+   Result expected,
+   error_code ec = {},
+   resp3::type error_type = resp3::type::invalid)
 {
    return expect<Result>{in, expected, ec, error_type};
 }
@@ -99,7 +110,7 @@ void test_sync(expect<Result> e)
    error_code ec;
    auto const res = parse(p, e.in, adapter, ec);
 
-   BOOST_TEST(res); // None of these tests need more data.
+   BOOST_TEST(res);  // None of these tests need more data.
 
    if (ec) {
       BOOST_CHECK_EQUAL(ec, e.ec);
@@ -123,7 +134,7 @@ void test_sync2(expect<Result> e)
    error_code ec;
    auto const res = parse(p, e.in, adapter, ec);
 
-   BOOST_TEST(res); // None of these tests need more data.
+   BOOST_TEST(res);  // None of these tests need more data.
    BOOST_CHECK_EQUAL(ec, e.ec);
 }
 
@@ -153,6 +164,8 @@ auto make_blob_string(std::string const& b)
 
 result<std::optional<int>> op_int_ok = 11;
 result<std::optional<bool>> op_bool_ok = true;
+
+// clang-format off
 
 // TODO: Test a streamed string that is not finished with a string of
 // size 0 but other command comes in.
@@ -461,12 +474,11 @@ generic_response const attr_e1b
    test(make_expected(S10b, node_type{{resp3::type::simple_error, 1UL, 0UL, {""}}}, {}, resp3::type::simple_error)); \
    test(make_expected(S12a, node_type{{resp3::type::blob_error, 1UL, 0UL, {"SYNTAX invalid syntax"}}}, {}, resp3::type::blob_error));\
    test(make_expected(S12b, node_type{{resp3::type::blob_error, 1UL, 0UL, {}}}, {}, resp3::type::blob_error));\
-   test(make_expected(S12c, result<ignore_t>{}, boost::redis::error::resp3_blob_error));\
+   test(make_expected(S12c, result<ignore_t>{}, boost::redis::error::resp3_blob_error));
 
-BOOST_AUTO_TEST_CASE(sansio)
-{
-   NUMBER_TEST_CONDITIONS(test_sync)
-}
+// clang-format on
+
+BOOST_AUTO_TEST_CASE(sansio){NUMBER_TEST_CONDITIONS(test_sync)}
 
 BOOST_AUTO_TEST_CASE(ignore_adapter_simple_error)
 {
@@ -478,10 +490,7 @@ BOOST_AUTO_TEST_CASE(ignore_adapter_blob_error)
    test_sync2(make_expected(S12a, ignore, boost::redis::error::resp3_blob_error));
 }
 
-BOOST_AUTO_TEST_CASE(ignore_adapter_no_error)
-{
-   test_sync2(make_expected(S05b, ignore));
-}
+BOOST_AUTO_TEST_CASE(ignore_adapter_no_error) { test_sync2(make_expected(S05b, ignore)); }
 
 //-----------------------------------------------------------------------------------
 void check_error(char const* name, boost::redis::error ev)
@@ -492,10 +501,9 @@ void check_error(char const* name, boost::redis::error ev)
    BOOST_TEST(!ec.message().empty());
    BOOST_TEST(cat.equivalent(
       static_cast<std::underlying_type<boost::redis::error>::type>(ev),
-          ec.category().default_error_condition(
-              static_cast<std::underlying_type<boost::redis::error>::type>(ev))));
-   BOOST_TEST(cat.equivalent(ec,
-      static_cast<std::underlying_type<boost::redis::error>::type>(ev)));
+      ec.category().default_error_condition(
+         static_cast<std::underlying_type<boost::redis::error>::type>(ev))));
+   BOOST_TEST(cat.equivalent(ec, static_cast<std::underlying_type<boost::redis::error>::type>(ev)));
 }
 
 BOOST_AUTO_TEST_CASE(cover_error)
@@ -606,7 +614,7 @@ BOOST_AUTO_TEST_CASE(adapter_as)
    result<std::set<std::string>> set;
    auto adapter = adapt2(set);
 
-   for (auto const& e: set_expected1a.value()) {
+   for (auto const& e : set_expected1a.value()) {
       error_code ec;
       adapter(e, ec);
    }

--- a/test/test_low_level_sync_sans_io.cpp
+++ b/test/test_low_level_sync_sans_io.cpp
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(issue_210_non_empty_set_size_one)
       deserialize(wire, adapt2(resp));
 
       BOOST_CHECK_EQUAL(std::get<0>(resp.value()).value(), 1);
-      BOOST_CHECK_EQUAL(std::get<1>(resp.value()).value().size(), 1);
+      BOOST_CHECK_EQUAL(std::get<1>(resp.value()).value().size(), 1u);
       BOOST_CHECK_EQUAL(std::get<1>(resp.value()).value().at(0), std::string{"foo"});
       BOOST_CHECK_EQUAL(std::get<2>(resp.value()).value(), "this_should_not_be_in_set");
       BOOST_CHECK_EQUAL(std::get<3>(resp.value()).value(), 2);
@@ -264,11 +264,11 @@ BOOST_AUTO_TEST_CASE(multiplexer_push)
    auto const ret = mpx.commit_read(ec);
 
    BOOST_TEST(ret.first.value());
-   BOOST_CHECK_EQUAL(ret.second, 16);
+   BOOST_CHECK_EQUAL(ret.second, 16u);
 
    // TODO: Provide operator << for generic_response so we can compare
    // the whole vector.
-   BOOST_CHECK_EQUAL(resp.value().size(), 3);
+   BOOST_CHECK_EQUAL(resp.value().size(), 3u);
    BOOST_CHECK_EQUAL(resp.value().at(1).value, "one");
    BOOST_CHECK_EQUAL(resp.value().at(2).value, "two");
 
@@ -294,11 +294,11 @@ BOOST_AUTO_TEST_CASE(multiplexer_push_needs_more)
    ret = mpx.commit_read(ec);
 
    BOOST_TEST(ret.first.value());
-   BOOST_CHECK_EQUAL(ret.second, 16);
+   BOOST_CHECK_EQUAL(ret.second, 16u);
 
    // TODO: Provide operator << for generic_response so we can compare
    // the whole vector.
-   BOOST_CHECK_EQUAL(resp.value().size(), 3);
+   BOOST_CHECK_EQUAL(resp.value().size(), 3u);
    BOOST_CHECK_EQUAL(resp.value().at(1).value, "one");
    BOOST_CHECK_EQUAL(resp.value().at(2).value, "two");
 }
@@ -343,8 +343,8 @@ BOOST_AUTO_TEST_CASE(multiplexer_pipeline)
 
    // There are three requests to coalesce, a second call should do
    // nothing.
-   BOOST_CHECK_EQUAL(mpx.prepare_write(), 3);
-   BOOST_CHECK_EQUAL(mpx.prepare_write(), 0);
+   BOOST_CHECK_EQUAL(mpx.prepare_write(), 3u);
+   BOOST_CHECK_EQUAL(mpx.prepare_write(), 0u);
 
    // After coalescing the requests for writing their statuses should
    // be changed to "staged".
@@ -354,7 +354,7 @@ BOOST_AUTO_TEST_CASE(multiplexer_pipeline)
 
    // There are no waiting requests to cancel since they are all
    // staged.
-   BOOST_CHECK_EQUAL(mpx.cancel_waiting(), 0);
+   BOOST_CHECK_EQUAL(mpx.cancel_waiting(), 0u);
 
    // Since the requests haven't been sent (written) the done
    // callback should not have been called yet.
@@ -365,11 +365,11 @@ BOOST_AUTO_TEST_CASE(multiplexer_pipeline)
    // The commit_write call informs the multiplexer the payload was
    // sent (e.g.  written to the socket). This step releases requests
    // that has no response.
-   BOOST_CHECK_EQUAL(mpx.commit_write(), 1);
+   BOOST_CHECK_EQUAL(mpx.commit_write(), 1u);
 
    // The staged status should now have changed to written.
    BOOST_TEST(item1.elem_ptr->is_written());
-   BOOST_TEST(item2.elem_ptr->is_written());
+   BOOST_TEST(item2.elem_ptr->is_done());
    BOOST_TEST(item3.elem_ptr->is_written());
 
    // The done status should still be unchanged on requests that
@@ -387,7 +387,7 @@ BOOST_AUTO_TEST_CASE(multiplexer_pipeline)
 
    // The read operation should have been successfull.
    BOOST_TEST(ret.first.has_value());
-   BOOST_TEST(ret.second != 0);
+   BOOST_TEST(ret.second != 0u);
 
    // The read buffer should also be empty now
    BOOST_TEST(mpx.get_read_buffer().empty());

--- a/test/test_low_level_sync_sans_io.cpp
+++ b/test/test_low_level_sync_sans_io.cpp
@@ -369,7 +369,7 @@ BOOST_AUTO_TEST_CASE(multiplexer_pipeline)
 
    // The staged status should now have changed to written.
    BOOST_TEST(item1.elem_ptr->is_written());
-   BOOST_TEST(item2.elem_ptr->is_done());
+   BOOST_TEST(item2.elem_ptr->is_written());
    BOOST_TEST(item3.elem_ptr->is_written());
 
    // The done status should still be unchanged on requests that

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -295,6 +295,8 @@ def _run_b2_tests(
         'toolset={}'.format(toolset),
         'cxxstd={}'.format(cxxstd),
         'variant={}'.format(variant),
+        'warnings=extra',
+        'warnings-as-errors=on',
         '-j4',
         'libs/redis/test'
     ])


### PR DESCRIPTION
Fixes some warnings due to unused variables, signed to unsigned comparisons, and superfluous moves