### PR TITLE
Fixes a memory corruption in logger and adds sanitizer builds to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,49 +133,49 @@ jobs:
         include:
           - toolset: gcc-11
             install: g++-11
-            os: ubuntu-latest
+            container: ubuntu:22.04
             cxxstd: '17'
             build-type: 'Debug'
             ldflags: ''
 
           - toolset: gcc-11
             install: g++-11
-            os: ubuntu-latest
+            container: ubuntu:22.04
             cxxstd: '20'
             build-type: 'Release'
             ldflags: ''
 
           - toolset: clang-11
             install: clang-11
-            os: ubuntu-latest
+            container: ubuntu:22.04
             cxxstd: '17'
             build-type: 'Debug'
             ldflags: ''
 
           - toolset: clang-11
             install: clang-11
-            os: ubuntu-latest
+            container: ubuntu:22.04
             cxxstd: '20'
             build-type: 'Debug'
             ldflags: ''
 
           - toolset: clang-13
             install: clang-13
-            os: ubuntu-latest
+            container: ubuntu:22.04
             cxxstd: '17'
             build-type: 'Release'
             ldflags: ''
 
           - toolset: clang-13
             install: clang-13
-            os: ubuntu-latest
+            container: ubuntu:22.04
             cxxstd: '20'
             build-type: 'Release'
             ldflags: ''
 
           - toolset: clang-14
             install: 'clang-14 libc++-14-dev libc++abi-14-dev'
-            os: ubuntu-latest
+            container: ubuntu:22.04
             cxxstd: '17'
             build-type: 'Debug'
             cxxflags: '-stdlib=libc++'
@@ -183,7 +183,7 @@ jobs:
 
           - toolset: clang-14
             install: 'clang-14 libc++-14-dev libc++abi-14-dev'
-            os: ubuntu-latest
+            container: ubuntu:22.04
             cxxstd: '20'
             build-type: 'Release'
             cxxflags: '-stdlib=libc++'
@@ -191,7 +191,7 @@ jobs:
           
           - toolset: clang-19
             install: 'clang-19'
-            os: ubuntu-latest
+            container: ubuntu:24.04
             cxxstd: '23'
             build-type: 'Debug'
             cxxflags: '-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all'
@@ -199,13 +199,13 @@ jobs:
           
           - toolset: gcc-14
             install: 'g++-14'
-            os: ubuntu-latest
+            container: ubuntu:24.04
             cxxstd: '23'
             build-type: 'Debug'
             cxxflags: '-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all'
             ldflags: '-fsanitize=address -fsanitize=undefined'
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     env:
       CXXFLAGS: ${{matrix.cxxflags}} -Wall -Wextra
       LDFLAGS:  ${{matrix.ldflags}}
@@ -217,7 +217,7 @@ jobs:
     
     - name: Set up the required containers
       run: |
-        docker compose -f tools/docker-compose.yml up -d --wait || (docker compose logs; exit 1)
+        IMAGE=${{ matrix.container }} docker compose -f tools/docker-compose.yml up -d --wait || (docker compose logs; exit 1)
       
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,22 @@ jobs:
             build-type: 'Release'
             cxxflags: '-stdlib=libc++'
             ldflags: '-lc++'
+          
+          - toolset: clang-19
+            install: 'clang-19'
+            os: ubuntu-latest
+            cxxstd: '23'
+            build-type: 'Debug'
+            cxxflags: '-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all'
+            ldflags: '-fsanitize=address -fsanitize=undefined'
+          
+          - toolset: gcc-14
+            install: 'g++-14'
+            os: ubuntu-latest
+            cxxstd: '23'
+            build-type: 'Debug'
+            cxxflags: '-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all'
+            ldflags: '-fsanitize=address -fsanitize=undefined'
 
     runs-on: ${{ matrix.os }}
     env:

--- a/include/boost/redis/logger.hpp
+++ b/include/boost/redis/logger.hpp
@@ -12,6 +12,7 @@
 #include <boost/asio/ip/tcp.hpp>
 
 #include <string>
+#include <string_view>
 
 namespace boost::system {
 class error_code;
@@ -132,7 +133,7 @@ public:
 private:
    void write_prefix();
    level level_;
-   std::string_view prefix_;
+   std::string prefix_;
 };
 
 }  // namespace boost::redis

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - 6379:6379
       - 6380:6380
   builder:
-    image: ubuntu:22.04
+    image: $IMAGE
     container_name: builder
     tty: true
     environment:


### PR DESCRIPTION
logger now owns the prefix string
This fixes a use-after-stack-return memory error in async_run
Adds a clang-19 and a gcc-14 build to CI with the address and undefined behavior sanitizer enabled

close #260 