### PR TITLE
Uses ignore as default for connection::async_exec

### DIFF
--- a/include/boost/redis/connection.hpp
+++ b/include/boost/redis/connection.hpp
@@ -898,8 +898,8 @@ public:
    std::size_t receive(system::error_code& ec) { return impl_.receive(ec); }
 
    /// Calls `boost::redis::basic_connection::async_exec`.
-   template <class Response, class CompletionToken = asio::deferred_t>
-   auto async_exec(request const& req, Response& resp, CompletionToken&& token = {})
+   template <class Response = ignore_t, class CompletionToken = asio::deferred_t>
+   auto async_exec(request const& req, Response& resp = ignore, CompletionToken&& token = {})
    {
       return async_exec(req, any_adapter(resp), std::forward<CompletionToken>(token));
    }

--- a/test/test_conn_echo_stress.cpp
+++ b/test/test_conn_echo_stress.cpp
@@ -79,7 +79,7 @@ auto push_consumer(connection& conn, int expected) -> net::awaitable<void>
 auto echo_session(connection& conn, const request& pubs, int n) -> net::awaitable<void>
 {
    for (auto i = 0; i < n; ++i)
-      co_await conn.async_exec(pubs, ignore);
+      co_await conn.async_exec(pubs);
 }
 
 void rethrow_on_error(std::exception_ptr exc)


### PR DESCRIPTION
Updates test_conn_echo_stress.cpp to use this default

close #264