### PR TITLE
Adds Valkey CIs and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
             cxxstd: '17'
             build-type: 'Debug'
             ldflags: ''
+            server: "redis:7.4.5-alpine"
 
           - toolset: gcc-11
             install: g++-11
@@ -144,6 +145,7 @@ jobs:
             cxxstd: '20'
             build-type: 'Release'
             ldflags: ''
+            server: "redis:7.4.5-alpine"
 
           - toolset: clang-11
             install: clang-11
@@ -151,6 +153,7 @@ jobs:
             cxxstd: '17'
             build-type: 'Debug'
             ldflags: ''
+            server: "redis:7.4.5-alpine"
 
           - toolset: clang-11
             install: clang-11
@@ -158,6 +161,7 @@ jobs:
             cxxstd: '20'
             build-type: 'Debug'
             ldflags: ''
+            server: "redis:7.4.5-alpine"
 
           - toolset: clang-13
             install: clang-13
@@ -165,6 +169,7 @@ jobs:
             cxxstd: '17'
             build-type: 'Release'
             ldflags: ''
+            server: "redis:8.2.1-alpine"
 
           - toolset: clang-13
             install: clang-13
@@ -172,6 +177,7 @@ jobs:
             cxxstd: '20'
             build-type: 'Release'
             ldflags: ''
+            server: "redis:8.2.1-alpine"
 
           - toolset: clang-14
             install: 'clang-14 libc++-14-dev libc++abi-14-dev'
@@ -180,6 +186,7 @@ jobs:
             build-type: 'Debug'
             cxxflags: '-stdlib=libc++'
             ldflags: '-lc++'
+            server: "redis:8.2.1-alpine"
 
           - toolset: clang-14
             install: 'clang-14 libc++-14-dev libc++abi-14-dev'
@@ -188,6 +195,7 @@ jobs:
             build-type: 'Release'
             cxxflags: '-stdlib=libc++'
             ldflags: '-lc++'
+            server: "redis:8.2.1-alpine"
           
           - toolset: clang-19
             install: 'clang-19'
@@ -196,6 +204,7 @@ jobs:
             build-type: 'Debug'
             cxxflags: '-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all'
             ldflags: '-fsanitize=address -fsanitize=undefined'
+            server: "redis:8.2.1-alpine"
 
           - toolset: gcc-14
             install: 'g++-14'
@@ -203,6 +212,7 @@ jobs:
             cxxstd: '23'
             build-type: 'Debug'
             cxxflags: '-DBOOST_ASIO_DISABLE_LOCAL_SOCKETS=1' # If a system had no UNIX socket support, we build correctly
+            server: "valkey/valkey:8.1.3-alpine"
           
           - toolset: gcc-14
             install: 'g++-14'
@@ -211,6 +221,7 @@ jobs:
             build-type: 'Debug'
             cxxflags: '-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all'
             ldflags: '-fsanitize=address -fsanitize=undefined'
+            server: "valkey/valkey:8.1.3-alpine"
 
     runs-on: ubuntu-latest
     env:
@@ -224,7 +235,7 @@ jobs:
     
     - name: Set up the required containers
       run: |
-        IMAGE=${{ matrix.container }} docker compose -f tools/docker-compose.yml up -d --wait || (docker compose logs; exit 1)
+        BUILDER_IMAGE=${{ matrix.container }} SERVER_IMAGE=${{ matrix.server }} docker compose -f tools/docker-compose.yml up -d --wait || (docker compose logs; exit 1)
       
     - name: Install dependencies
       run: |

--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -8,7 +8,8 @@
 [#intro]
 = Introduction
 
-Boost.Redis is a high-level https://redis.io/[Redis] client library built on top of
+Boost.Redis is a high-level https://redis.io/[Redis] and https://valkey.io/[Valkey]
+client library built on top of
 https://www.boost.org/doc/libs/latest/doc/html/boost_asio.html[Boost.Asio]
 that implements the Redis protocol
 https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md[RESP3].
@@ -19,7 +20,8 @@ The requirements for using Boost.Redis are:
 
 * Boost 1.84 or higher. Boost.Redis is included in Boost installations since Boost 1.84.
 * pass:[C++17] or higher. Supported compilers include gcc 11 and later, clang 11 and later, and Visual Studio 16 (2019) and later.
-* Redis 6 or higher (must support RESP3).
+* Redis 6 or higher, or Valkey (any version). The database server must support RESP3.
+  We intend to maintain compatibility with both Redis and Valkey in the long-run.
 * OpenSSL.
 
 The documentation assumes basic-level knowledge about https://redis.io/docs/[Redis] and https://www.boost.org/doc/libs/latest/doc/html/boost_asio.html[Boost.Asio].

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redis:
-    image: "redis:alpine"
+    image: ${SERVER_IMAGE}
     entrypoint: "/docker/entrypoint.sh"
     volumes:
       - ./docker:/docker
@@ -9,7 +9,7 @@ services:
       - 6379:6379
       - 6380:6380
   builder:
-    image: $IMAGE
+    image: ${BUILDER_IMAGE}
     container_name: builder
     tty: true
     environment:


### PR DESCRIPTION
Adds Valkey CIs

Modifies existing builds to use different database flavors and versions:
* Redis 7.4.5
* Redis 8.2.1
* Valkey 8.1.3

Adds docs on support plans for Valkey

close #294