### PR TITLE
Adds a connection health flag to the multiplexer

### DIFF
--- a/include/boost/redis/connection.hpp
+++ b/include/boost/redis/connection.hpp
@@ -102,7 +102,7 @@ struct connection_impl {
       {
          while (true) {
             // Invoke the state machine
-            auto act = fsm_.resume(obj_->is_open(), self.get_cancellation_state().cancelled());
+            auto act = fsm_.resume(self.get_cancellation_state().cancelled());
 
             // Do what the FSM said
             switch (act.type()) {

--- a/include/boost/redis/connection.hpp
+++ b/include/boost/redis/connection.hpp
@@ -861,8 +861,8 @@ public:
     */
    void cancel(operation op = operation::all) { impl_->cancel(op); }
 
-   // TODO: handle this
-   auto run_is_canceled() const noexcept { return impl_->mpx_.get_cancel_run_state(); }
+   BOOST_DEPRECATED("This function is internal and will be removed in the next release.")
+   bool run_is_canceled() const noexcept { return !impl_->mpx_.is_connection_healthy(); }
 
    /// Returns true if the connection will try to reconnect if an error is encountered.
    bool will_reconnect() const noexcept { return impl_->will_reconnect(); }

--- a/include/boost/redis/detail/exec_fsm.hpp
+++ b/include/boost/redis/detail/exec_fsm.hpp
@@ -64,7 +64,7 @@ public:
    , elem_(std::move(elem))
    { }
 
-   exec_action resume(bool connection_is_open, asio::cancellation_type_t cancel_state);
+   exec_action resume(asio::cancellation_type_t cancel_state);
 };
 
 }  // namespace boost::redis::detail

--- a/include/boost/redis/impl/exec_fsm.ipp
+++ b/include/boost/redis/impl/exec_fsm.ipp
@@ -25,14 +25,16 @@ inline bool is_cancellation(asio::cancellation_type_t type)
               asio::cancellation_type_t::terminal));
 }
 
-exec_action exec_fsm::resume(bool connection_is_open, asio::cancellation_type_t cancel_state)
+exec_action exec_fsm::resume(asio::cancellation_type_t cancel_state)
 {
    switch (resume_point_) {
       BOOST_REDIS_CORO_INITIAL
 
       // Check whether the user wants to wait for the connection to
       // be established.
-      if (elem_->get_request().get_config().cancel_if_not_connected && !connection_is_open) {
+      if (
+         elem_->get_request().get_config().cancel_if_not_connected &&
+         !mpx_->is_connection_healthy()) {
          BOOST_REDIS_YIELD(resume_point_, 1, exec_action_type::immediate)
          elem_.reset();  // Deallocate memory before finalizing
          return system::error_code(error::not_connected);

--- a/test/test_multiplexer.cpp
+++ b/test/test_multiplexer.cpp
@@ -484,7 +484,7 @@ void test_cancel_on_connection_lost()
    BOOST_TEST(item_waiting2.elem_ptr->is_waiting());
 
    // Trigger a connection lost event
-   mpx.cancel_on_conn_lost();
+   mpx.on_connection_down();
 
    // The ones with the cancellation settings set to false are back to waiting.
    // Others are cancelled
@@ -499,7 +499,7 @@ void test_cancel_on_connection_lost()
    BOOST_TEST(item_waiting2.done);
 
    // Triggering it again does nothing
-   mpx.cancel_on_conn_lost();
+   mpx.on_connection_down();
    BOOST_TEST(!item_written1.done);
    BOOST_TEST(item_written1.elem_ptr->is_waiting());
 }


### PR DESCRIPTION
Uses this flag in async_exec to make cancel_if_not_connected reliable
Deprecates basic_connection::run_is_canceled()
Introduces preconditions in multiplexer methods to be called by the reader and writer tasks
Ensures that request cancellation due to a connection lost is only called after the reader and writer have finished, avoiding potential race conditions

close #236 
