### PR TITLE
Adds reliable cancellation support to async_exec

### DIFF
--- a/include/boost/redis/connection.hpp
+++ b/include/boost/redis/connection.hpp
@@ -118,9 +118,6 @@ struct connection_impl {
                case exec_action_type::wait_for_response:
                   notifier_->async_receive(std::move(self));
                   return;
-               case exec_action_type::cancel_run:
-                  obj_->cancel(operation::run);
-                  continue;  // this action does not require yielding
                case exec_action_type::done:
                   notifier_.reset();
                   self.complete(act.error(), act.bytes_read());

--- a/include/boost/redis/detail/exec_fsm.hpp
+++ b/include/boost/redis/detail/exec_fsm.hpp
@@ -29,7 +29,6 @@ enum class exec_action_type
    done,                // Call the final handler
    notify_writer,       // Notify the writer task
    wait_for_response,   // Wait to be notified
-   cancel_run,          // Cancel the connection's run operation
 };
 
 class exec_action {

--- a/include/boost/redis/detail/multiplexer.hpp
+++ b/include/boost/redis/detail/multiplexer.hpp
@@ -95,6 +95,16 @@ public:
 
       auto get_adapter() -> any_adapter& { return adapter_; }
 
+      // Marks the element as an abandoned request. An abandoned request
+      // won't cause problems when its response arrives, but that response will be ignored.
+      void mark_as_abandoned();
+
+      [[nodiscard]]
+      bool is_abandoned() const
+      {
+         return !req_;
+      }
+
    private:
       enum class status
       {
@@ -116,7 +126,7 @@ public:
       std::size_t read_size_;
    };
 
-   auto remove(std::shared_ptr<elem> const& ptr) -> bool;
+   void cancel(std::shared_ptr<elem> const& ptr);
 
    [[nodiscard]]
    auto prepare_write() -> std::size_t;

--- a/include/boost/redis/impl/connection_logger.ipp
+++ b/include/boost/redis/impl/connection_logger.ipp
@@ -42,7 +42,6 @@ auto to_string(exec_action_type t) noexcept -> char const*
       BOOST_REDIS_EXEC_SWITCH_CASE(done);
       BOOST_REDIS_EXEC_SWITCH_CASE(notify_writer);
       BOOST_REDIS_EXEC_SWITCH_CASE(wait_for_response);
-      BOOST_REDIS_EXEC_SWITCH_CASE(cancel_run);
       default: return "exec_action_type::<invalid type>";
    }
 }

--- a/include/boost/redis/impl/multiplexer.ipp
+++ b/include/boost/redis/impl/multiplexer.ipp
@@ -5,6 +5,7 @@
  */
 
 #include <boost/redis/detail/multiplexer.hpp>
+#include <boost/redis/ignore.hpp>
 #include <boost/redis/request.hpp>
 
 #include <boost/asio/error.hpp>
@@ -37,14 +38,23 @@ auto multiplexer::elem::commit_response(std::size_t read_size) -> void
    --remaining_responses_;
 }
 
-bool multiplexer::remove(std::shared_ptr<elem> const& ptr)
+void multiplexer::elem::mark_as_abandoned()
+{
+   req_ = nullptr;
+   adapter_ = any_adapter(ignore);  // TODO: apparently ignore doesn't ignore errors
+   set_done_callback([] { });
+}
+
+void multiplexer::cancel(std::shared_ptr<elem> const& ptr)
 {
    if (ptr->is_waiting()) {
+      // We can safely remove it from the queue, since it hasn't been sent yet
       reqs_.erase(std::remove(std::begin(reqs_), std::end(reqs_), ptr));
-      return true;
+   } else {
+      // Removing the request would cause trouble when the response arrived.
+      // Mark it as abandoned, so the response is discarded when it arrives
+      ptr->mark_as_abandoned();
    }
-
-   return false;
 }
 
 std::size_t multiplexer::commit_write()
@@ -67,6 +77,8 @@ std::size_t multiplexer::commit_write()
 
 void multiplexer::add(std::shared_ptr<elem> const& info)
 {
+   BOOST_ASSERT(!info->is_abandoned());
+
    reqs_.push_back(info);
 
    if (request_access::has_priority(info->get_request())) {
@@ -164,8 +176,9 @@ std::size_t multiplexer::prepare_write()
          return !ri->is_waiting();
       });
 
-   std::for_each(point, std::cend(reqs_), [this](auto const& ri) {
+   std::for_each(point, std::cend(reqs_), [this](const std::shared_ptr<elem>& ri) {
       // Stage the request.
+      BOOST_ASSERT(!ri->is_abandoned());
       write_buffer_ += ri->get_request().payload();
       ri->mark_staged();
       usage_.commands_sent += ri->get_request().get_commands();
@@ -205,8 +218,13 @@ auto multiplexer::cancel_on_conn_lost() -> std::size_t
    }
 
    // Must return false if the request should be removed.
-   auto cond = [](auto const& ptr) {
+   auto cond = [](const std::shared_ptr<elem>& ptr) {
       BOOST_ASSERT(ptr != nullptr);
+
+      // Abandoned requests only make sense because a response for them might arrive.
+      // They should be discarded after the connection is lost
+      if (ptr->is_abandoned())
+         return false;
 
       if (ptr->is_waiting()) {
          return !ptr->get_request().get_config().cancel_on_connection_lost;
@@ -282,9 +300,12 @@ bool multiplexer::is_next_push(std::string_view data) const noexcept
 
 std::size_t multiplexer::release_push_requests()
 {
-   auto point = std::stable_partition(std::begin(reqs_), std::end(reqs_), [](auto const& ptr) {
-      return !(ptr->is_written() && ptr->get_request().get_expected_responses() == 0);
-   });
+   auto point = std::stable_partition(
+      std::begin(reqs_),
+      std::end(reqs_),
+      [](const std::shared_ptr<elem>& ptr) {
+         return !(ptr->is_written() && ptr->get_remaining_responses() == 0u);
+      });
 
    std::for_each(point, std::end(reqs_), [](auto const& ptr) {
       ptr->notify_done();


### PR DESCRIPTION
* Terminal cancellation in async_exec no longer tears down the connection when the cancelled request has been sent to the server.
* Adds support for partial cancellation in async_exec with the same semantics.