### PR TITLE
Adds support for asio::cancel_after

### DIFF
--- a/doc/modules/ROOT/nav.adoc
+++ b/doc/modules/ROOT/nav.adoc
@@ -1,5 +1,6 @@
 * xref:index.adoc[Introduction]
 * xref:requests_responses.adoc[]
+* xref:cancellation.adoc[]
 * xref:serialization.adoc[]
 * xref:logging.adoc[]
 * xref:benchmarks.adoc[]

--- a/doc/modules/ROOT/pages/cancellation.adoc
+++ b/doc/modules/ROOT/pages/cancellation.adoc
@@ -1,0 +1,55 @@
+//
+// Copyright (c) 2025 Marcelo Zimbres Silva (mzimbres@gmail.com),
+// Ruben Perez Hidalgo (rubenperez038 at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+= Cancellation
+
+Requests may take a very long time. If the server is down, they may suspend forever,
+waiting for the server to be up. Fortunately, requests can be cancelled after
+a certain time using asio::cancel_after:
+
+```
+request req;
+// ...
+
+co_await conn.async_exec(req, resp, asio::cancel_after(10s));
+```
+
+If the request hasn't been responded after 10 seconds, it will
+fail with `asio::error::operation_aborted`. With the coroutine
+usage above, this means a `boost::system::system_error` exception
+with the error code mentioned above.
+
+== Retrying idempotent requests
+
+By default, the library waits until the server is up,
+and then sends the request. But what happens if there is a communication
+error after sending the request, but before receiving a response?
+
+In this situation, we don't know if the request was processed by the server or not.
+And we have no way to know it. By default, the library mark these requests as
+failed with `asio::error::operation_aborted`. (TODO: do we want another error code here?).
+
+Some requests can be executed several times and result in the same outcome
+as executing them only once. We say that these requests are idempotent.
+The `SET` command is idempotent, while `INCR` is not.
+
+If you know that a request contains only idempotent commands,
+you can instruct Redis to retry the request on failure, even
+if the library is unsure about whether the server received the request or not.
+You can do so by setting request::config::cancel_if_unresponded to false:
+
+```
+request req;
+req.push("SET", "my_key", 42); // idempotent
+req.get_config().cancel_on_connection_lost = false; // TODO: we shouldn't need this
+req.get_config().cancel_if_unresponded = false; // retry
+
+// Makes sure that the key is set, even in the presence of network errors.
+// This may suspend for an unspecified period of time if the server is down.
+co_await conn.async_exec(req, ignore);
+```

--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -139,6 +139,7 @@ receiver(std::shared_ptr<connection> conn) -> net::awaitable<void>
 
 Here is a list of topics that you might be interested in:
 
+* xref:cancellation.adoc[Setting timeouts to requests and managing cancellation].
 * xref:requests_responses.adoc[More on requests and responses].
 * xref:serialization.adoc[Serializing and parsing into custom types].
 * xref:logging.adoc[Configuring logging].

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -27,6 +27,7 @@ make_testable_example(cpp20_intro 20)
 make_testable_example(cpp20_containers 20)
 make_testable_example(cpp20_json 20)
 make_testable_example(cpp20_unix_sockets 20)
+make_testable_example(cpp20_timeouts 20)
 
 make_example(cpp20_subscriber 20)
 make_example(cpp20_streams 20)

--- a/example/cpp20_timeouts.cpp
+++ b/example/cpp20_timeouts.cpp
@@ -1,0 +1,49 @@
+/* Copyright (c) 2018-2022 Marcelo Zimbres Silva (mzimbres@gmail.com)
+ *
+ * Distributed under the Boost Software License, Version 1.0. (See
+ * accompanying file LICENSE.txt)
+ */
+
+#include <boost/redis/connection.hpp>
+
+#include <boost/asio/cancel_after.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/consign.hpp>
+#include <boost/asio/detached.hpp>
+
+#include <iostream>
+
+#if defined(BOOST_ASIO_HAS_CO_AWAIT)
+
+namespace asio = boost::asio;
+using boost::redis::request;
+using boost::redis::response;
+using boost::redis::config;
+using boost::redis::connection;
+using namespace std::chrono_literals;
+
+// Called from the main function (see main.cpp)
+auto co_main(config cfg) -> asio::awaitable<void>
+{
+   auto conn = std::make_shared<connection>(co_await asio::this_coro::executor);
+   conn->async_run(cfg, asio::consign(asio::detached, conn));
+
+   // A request containing only a ping command.
+   request req;
+   req.push("PING", "Hello world");
+
+   // Response where the PONG response will be stored.
+   response<std::string> resp;
+
+   // Executes the request with a timeout. If the server is down,
+   // async_exec will wait until it's back again, so it,
+   // may suspend for a long time.
+   // For this reason, it's good practice to set a timeout to requests with cancel_after.
+   // If the request hasn't completed after 10 seconds, an exception will be thrown.
+   co_await conn->async_exec(req, resp, asio::cancel_after(10s));
+   conn->cancel();
+
+   std::cout << "PING: " << std::get<0>(resp).value() << std::endl;
+}
+
+#endif  // defined(BOOST_ASIO_HAS_CO_AWAIT)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,6 +63,7 @@ make_test(test_issue_50)
 make_test(test_conversions)
 make_test(test_conn_tls)
 make_test(test_unix_sockets)
+make_test(test_conn_cancel_after)
 
 # Coverage
 set(

--- a/test/test_conn_cancel_after.cpp
+++ b/test/test_conn_cancel_after.cpp
@@ -26,32 +26,15 @@ using boost::redis::connection;
 
 namespace {
 
-void test_basic_connection_run()
+template <class Connection>
+void test_run()
 {
    // Setup
    asio::io_context ioc;
-   basic_connection<asio::io_context::executor_type> conn{ioc};
+   Connection conn{ioc};
    bool run_finished = false;
 
-   // async_run
-   conn.async_run(make_test_config(), asio::cancel_after(1ms, [&](error_code ec) {
-                     BOOST_TEST_EQ(ec, asio::error::operation_aborted);
-                     run_finished = true;
-                  }));
-
-   ioc.run_for(test_timeout);
-
-   BOOST_TEST(run_finished);
-}
-
-void test_connection_run()
-{
-   // Setup
-   asio::io_context ioc;
-   connection conn{ioc};
-   bool run_finished = false;
-
-   // async_run
+   // Call the function with a very short timeout
    conn.async_run(make_test_config(), asio::cancel_after(1ms, [&](error_code ec) {
                      BOOST_TEST_EQ(ec, asio::error::operation_aborted);
                      run_finished = true;
@@ -66,8 +49,8 @@ void test_connection_run()
 
 int main()
 {
-   test_basic_connection_run();
-   test_connection_run();
+   test_run<basic_connection<asio::io_context::executor_type>>();
+   test_run<connection>();
 
    return boost::report_errors();
 }

--- a/test/test_conn_cancel_after.cpp
+++ b/test/test_conn_cancel_after.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/asio/cancel_after.hpp>
 #include <boost/asio/error.hpp>
+#include <boost/asio/experimental/channel_error.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/core/lightweight_test.hpp>
 
@@ -83,7 +84,7 @@ void test_receive()
 
    // Call the function with a very short timeout.
    conn.async_receive(asio::cancel_after(1ms, [&](error_code ec, std::size_t) {
-      BOOST_TEST_EQ(ec, asio::error::operation_aborted);
+      BOOST_TEST_EQ(ec, asio::experimental::channel_errc::channel_cancelled);
       receive_finished = true;
    }));
 

--- a/test/test_conn_cancel_after.cpp
+++ b/test/test_conn_cancel_after.cpp
@@ -7,15 +7,15 @@
 //
 
 #include <boost/redis/connection.hpp>
+#include <boost/redis/ignore.hpp>
 #include <boost/redis/request.hpp>
 #include <boost/redis/response.hpp>
 
+#include <boost/asio/cancel_after.hpp>
+#include <boost/asio/error.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/core/lightweight_test.hpp>
 
-#include "boost/asio/cancel_after.hpp"
-#include "boost/asio/error.hpp"
-#include "boost/asio/io_context.hpp"
-#include "boost/redis/ignore.hpp"
 #include "common.hpp"
 
 using namespace std::chrono_literals;

--- a/test/test_conn_cancel_after.cpp
+++ b/test/test_conn_cancel_after.cpp
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2025 Marcelo Zimbres Silva (mzimbres@gmail.com),
+// Ruben Perez Hidalgo (rubenperez038 at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/redis/connection.hpp>
+#include <boost/redis/request.hpp>
+#include <boost/redis/response.hpp>
+
+#include <boost/core/lightweight_test.hpp>
+
+#include "boost/asio/cancel_after.hpp"
+#include "boost/asio/error.hpp"
+#include "boost/asio/io_context.hpp"
+#include "common.hpp"
+
+using namespace std::chrono_literals;
+namespace asio = boost::asio;
+using boost::system::error_code;
+using boost::redis::request;
+using boost::redis::basic_connection;
+using boost::redis::connection;
+
+namespace {
+
+void test_basic_connection()
+{
+   // Setup
+   asio::io_context ioc;
+   basic_connection<asio::io_context::executor_type> conn{ioc};
+   bool run_finished = false;
+
+   // async_run
+   conn.async_run(make_test_config(), asio::cancel_after(1ms, [&](error_code ec) {
+                     BOOST_TEST_EQ(ec, asio::error::operation_aborted);
+                     run_finished = true;
+                  }));
+
+   ioc.run_for(test_timeout);
+
+   BOOST_TEST(run_finished);
+}
+
+}  // namespace
+
+int main()
+{
+   test_basic_connection();
+
+   return boost::report_errors();
+}

--- a/test/test_conn_cancel_after.cpp
+++ b/test/test_conn_cancel_after.cpp
@@ -26,7 +26,7 @@ using boost::redis::connection;
 
 namespace {
 
-void test_basic_connection()
+void test_basic_connection_run()
 {
    // Setup
    asio::io_context ioc;
@@ -44,11 +44,30 @@ void test_basic_connection()
    BOOST_TEST(run_finished);
 }
 
+void test_connection_run()
+{
+   // Setup
+   asio::io_context ioc;
+   connection conn{ioc};
+   bool run_finished = false;
+
+   // async_run
+   conn.async_run(make_test_config(), asio::cancel_after(1ms, [&](error_code ec) {
+                     BOOST_TEST_EQ(ec, asio::error::operation_aborted);
+                     run_finished = true;
+                  }));
+
+   ioc.run_for(test_timeout);
+
+   BOOST_TEST(run_finished);
+}
+
 }  // namespace
 
 int main()
 {
-   test_basic_connection();
+   test_basic_connection_run();
+   test_connection_run();
 
    return boost::report_errors();
 }

--- a/test/test_conn_cancel_after.cpp
+++ b/test/test_conn_cancel_after.cpp
@@ -25,6 +25,7 @@ using boost::redis::request;
 using boost::redis::basic_connection;
 using boost::redis::connection;
 using boost::redis::ignore;
+using boost::redis::generic_response;
 
 namespace {
 
@@ -53,7 +54,7 @@ void test_exec()
    // Setup
    asio::io_context ioc;
    Connection conn{ioc};
-   bool run_finished = false;
+   bool exec_finished = false;
 
    request req;
    req.push("PING", "cancel_after");
@@ -62,12 +63,33 @@ void test_exec()
    // The connection is not being run, so these can't succeed
    conn.async_exec(req, ignore, asio::cancel_after(1ms, [&](error_code ec, std::size_t) {
                       BOOST_TEST_EQ(ec, asio::error::operation_aborted);
-                      run_finished = true;
+                      exec_finished = true;
                    }));
 
    ioc.run_for(test_timeout);
 
-   BOOST_TEST(run_finished);
+   BOOST_TEST(exec_finished);
+}
+
+template <class Connection>
+void test_receive()
+{
+   // Setup
+   asio::io_context ioc;
+   Connection conn{ioc};
+   bool receive_finished = false;
+   generic_response resp;
+   conn.set_receive_response(resp);
+
+   // Call the function with a very short timeout.
+   conn.async_receive(asio::cancel_after(1ms, [&](error_code ec, std::size_t) {
+      BOOST_TEST_EQ(ec, asio::error::operation_aborted);
+      receive_finished = true;
+   }));
+
+   ioc.run_for(test_timeout);
+
+   BOOST_TEST(receive_finished);
 }
 
 }  // namespace
@@ -79,6 +101,9 @@ int main()
 
    test_exec<basic_connection<asio::io_context::executor_type>>();
    test_exec<connection>();
+
+   test_receive<basic_connection<asio::io_context::executor_type>>();
+   test_receive<connection>();
 
    return boost::report_errors();
 }


### PR DESCRIPTION
* Adds support for asio::cancel_after in connection::{async_exec, async_run}
* Adds cancel_after tests
* Adds an example on using asio::cancel_after
* Adds a discussion page on timeouts and the `cancel_if_unresponded` flag

close #226 
