### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,6 @@ if (BOOST_REDIS_MAIN_PROJECT)
     align
     context
     core
-    static_assert
     pool
     date_time
     smart_ptr


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.