### PR TITLE
Guards benchmarks behind BOOST_REDIS_INTEGRATION_TESTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,12 +49,13 @@ if(BUILD_TESTING)
 
   # Tests and common utilities
   add_subdirectory(test)
-
-  # Benchmarks. Build them with tests to prevent code rotting
-  add_subdirectory(benchmarks)
-
-  # Examples. All of them require a real server running
+  
   if (BOOST_REDIS_INTEGRATION_TESTS)
+    # Benchmarks. Build them with tests to prevent code rotting.
+    # Guarded to prevent them from building in normal builds
+    add_subdirectory(benchmarks)
+
+    # Examples. All of them require a real server running
     add_subdirectory(example)
   endif()
 endif()

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,20 +1,11 @@
 
-add_library(benchmarks_options INTERFACE)
-target_link_libraries(benchmarks_options INTERFACE boost_redis_src)
-target_link_libraries(benchmarks_options INTERFACE boost_redis_project_options)
-target_compile_features(benchmarks_options INTERFACE cxx_std_20)
+add_library(boost_redis_benchmarks_options INTERFACE)
+target_link_libraries(boost_redis_benchmarks_options INTERFACE boost_redis_src)
+target_link_libraries(boost_redis_benchmarks_options INTERFACE boost_redis_project_options)
+target_compile_features(boost_redis_benchmarks_options INTERFACE cxx_std_20)
 
-add_executable(echo_server_client cpp/asio/echo_server_client.cpp)
-target_link_libraries(echo_server_client PRIVATE benchmarks_options)
+add_executable(boost_redis_echo_server_client cpp/asio/echo_server_client.cpp)
+target_link_libraries(boost_redis_echo_server_client PRIVATE boost_redis_benchmarks_options)
 
-add_executable(echo_server_direct cpp/asio/echo_server_direct.cpp)
-target_link_libraries(echo_server_direct PRIVATE benchmarks_options)
-
-# TODO
-#=======================================================================
-
-#.PHONY: bench
-#bench:
-#	pdflatex --jobname=echo-f0 benchmarks/benchmarks.tex
-#	pdflatex --jobname=echo-f1 benchmarks/benchmarks.tex
-# pdftoppm {input.pdf} {output.file} -png
+add_executable(boost_redis_echo_server_direct cpp/asio/echo_server_direct.cpp)
+target_link_libraries(boost_redis_echo_server_direct PRIVATE boost_redis_benchmarks_options)


### PR DESCRIPTION
Namespaces CMake target names in benchmarks
Guards benchmarks in the main CMake by BOOST_REDIS_INTEGRATION_TESTS. They are only built to prevent code rotting, and shouldn't be built by superproject builds except in our CIs