### PR TITLE
Recovers the B2 build on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,6 @@ jobs:
         include:
           #- { toolset: msvc-14.2, os: windows-2019 }
           - { toolset: msvc-14.3, os: windows-2022 }
-    env:
-      OPENSSL_ROOT: "C:\\Program Files\\OpenSSL"
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
 
-  #   - name: Setup Boost
-  #     run: python3 tools/ci.py setup-boost --source-dir=$(pwd)
+    - name: Setup Boost
+      run: python3 tools/ci.py setup-boost --source-dir=$(pwd)
 
-  #   - name: Build a Boost distribution using B2
-  #     run: |
-  #       python3 tools/ci.py build-b2-distro \
-  #         --toolset ${{ matrix.toolset }}
+    - name: Build a Boost distribution using B2
+      run: |
+        python3 tools/ci.py build-b2-distro \
+          --toolset ${{ matrix.toolset }}
 
     # No Redis server is available on this job, so integration tests are skipped.
     # Unit tests are built and run via the CMake superproject build.
@@ -93,6 +93,8 @@ jobs:
         include:
           #- { toolset: msvc-14.2, os: windows-2019 }
           - { toolset: msvc-14.3, os: windows-2022 }
+    env:
+      OPENSSL_ROOT: "C:\\Program Files\\OpenSSL"
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -110,11 +112,11 @@ jobs:
           --cxxstd 17,20 \
           --variant debug,release
 
-  # posix-cmake:
-  #   name: "CMake ${{ matrix.toolset }} ${{ matrix.cxxstd }} ${{ matrix.build-type }} ${{ matrix.cxxflags }}"
-  #   defaults:
-  #     run:
-  #       shell: bash
+  posix-cmake:
+    name: "CMake ${{ matrix.toolset }} ${{ matrix.cxxstd }} ${{ matrix.build-type }} ${{ matrix.cxxflags }}"
+    defaults:
+      run:
+        shell: bash
 
     strategy:
       fail-fast: false
@@ -364,13 +366,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
     
-  #   - name: Generate TLS certificates
-  #     run: |
-  #       ./tools/gen-certificates.sh
+    - name: Generate TLS certificates
+      run: |
+        ./tools/gen-certificates.sh
     
-  #   - name: Set up the required containers
-  #     run: |
-  #       BUILDER_IMAGE=${{ matrix.container }} SERVER_IMAGE=${{ matrix.server }} docker compose -f tools/docker-compose.yml up -d --wait || (docker compose logs; exit 1)
+    - name: Set up the required containers
+      run: |
+        BUILDER_IMAGE=${{ matrix.container }} SERVER_IMAGE=${{ matrix.server }} docker compose -f tools/docker-compose.yml up -d --wait || (docker compose logs; exit 1)
       
     - name: Install dependencies
       run: |
@@ -386,13 +388,13 @@ jobs:
           python3 \
           ${{ matrix.install }}
 
-  #   - name: Setup Boost
-  #     run: docker exec builder /boost-redis/tools/ci.py setup-boost --source-dir=/boost-redis
+    - name: Setup Boost
+      run: docker exec builder /boost-redis/tools/ci.py setup-boost --source-dir=/boost-redis
 
-  #   - name: Build a Boost distribution using B2
-  #     run: |
-  #       docker exec builder /boost-redis/tools/ci.py build-b2-distro \
-  #         --toolset ${{ matrix.toolset }}
+    - name: Build a Boost distribution using B2
+      run: |
+        docker exec builder /boost-redis/tools/ci.py build-b2-distro \
+          --toolset ${{ matrix.toolset }}
 
     # The CMake superproject build also drives the project tests, including
     # integration tests against the Redis server set up above.
@@ -432,11 +434,11 @@ jobs:
           "--cxxflags=${{ matrix.cxxflags }} -Werror" \
           "--ldflags=${{ matrix.ldflags }}"
 
-  # posix-b2:
-  #   name: "B2 ${{ matrix.toolset }}"
-  #   defaults:
-  #     run:
-  #       shell: bash
+  posix-b2:
+    name: "B2 ${{ matrix.toolset }}"
+    defaults:
+      run:
+        shell: bash
 
     strategy:
       fail-fast: false
@@ -477,33 +479,33 @@ jobs:
         apt-get update
         apt-get -y install python3 git g++ libssl-dev ${{ matrix.install }}
 
-  #   - name: Setup Boost
-  #     run: ./tools/ci.py setup-boost --source-dir=$(pwd)
+    - name: Setup Boost
+      run: ./tools/ci.py setup-boost --source-dir=$(pwd)
     
-  #   - name: Build and run project tests using B2
-  #     run: |
-  #       python3 tools/ci.py run-b2-tests \
-  #         --toolset ${{ matrix.toolset }} \
-  #         --cxxstd ${{ matrix.cxxstd }} \
-  #         --variant debug,release
+    - name: Build and run project tests using B2
+      run: |
+        python3 tools/ci.py run-b2-tests \
+          --toolset ${{ matrix.toolset }} \
+          --cxxstd ${{ matrix.cxxstd }} \
+          --variant debug,release
 
-  # # Checks that we don't have any errors in docs
-  # check-docs:
-  #   name: Check docs
-  #   defaults:
-  #     run:
-  #       shell: bash
+  # Checks that we don't have any errors in docs
+  check-docs:
+    name: Check docs
+    defaults:
+      run:
+        shell: bash
 
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v6
 
-  #   - name: Setup Boost
-  #     run: ./tools/ci.py setup-boost --source-dir=$(pwd)
+    - name: Setup Boost
+      run: ./tools/ci.py setup-boost --source-dir=$(pwd)
     
-  #   - name: Build docs
-  #     run: |
-  #       cd ~/boost-root
-  #       ./b2 libs/redis/doc
-  #       [ -f ~/boost-root/libs/redis/doc/html/index.html ]
+    - name: Build docs
+      run: |
+        cd ~/boost-root
+        ./b2 libs/redis/doc
+        [ -f ~/boost-root/libs/redis/doc/html/index.html ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,75 +11,75 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  windows-cmake:
-    name: "CMake ${{matrix.toolset}} ${{matrix.build-type}} C++${{matrix.cxxstd}}"
-    runs-on: ${{matrix.os}}
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          #- { toolset: msvc-14.2, os: windows-2019, generator: "Visual Studio 16 2019", cxxstd: '17', build-type: 'Debug',   build-shared-libs: 1 }
-          #- { toolset: msvc-14.2, os: windows-2019, generator: "Visual Studio 16 2019", cxxstd: '17', build-type: 'Release', build-shared-libs: 0 }
-          - { toolset: msvc-14.3, os: windows-2022, generator: "Visual Studio 17 2022", cxxstd: '20', build-type: 'Debug',   build-shared-libs: 0 }
-          - { toolset: msvc-14.3, os: windows-2022, generator: "Visual Studio 17 2022", cxxstd: '20', build-type: 'Release', build-shared-libs: 1 }
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v6
+  # windows-cmake:
+  #   name: "CMake ${{matrix.toolset}} ${{matrix.build-type}} C++${{matrix.cxxstd}}"
+  #   runs-on: ${{matrix.os}}
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         #- { toolset: msvc-14.2, os: windows-2019, generator: "Visual Studio 16 2019", cxxstd: '17', build-type: 'Debug',   build-shared-libs: 1 }
+  #         #- { toolset: msvc-14.2, os: windows-2019, generator: "Visual Studio 16 2019", cxxstd: '17', build-type: 'Release', build-shared-libs: 0 }
+  #         - { toolset: msvc-14.3, os: windows-2022, generator: "Visual Studio 17 2022", cxxstd: '20', build-type: 'Debug',   build-shared-libs: 0 }
+  #         - { toolset: msvc-14.3, os: windows-2022, generator: "Visual Studio 17 2022", cxxstd: '20', build-type: 'Release', build-shared-libs: 1 }
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v6
 
-    - name: Setup Boost
-      run: python3 tools/ci.py setup-boost --source-dir=$(pwd)
+  #   - name: Setup Boost
+  #     run: python3 tools/ci.py setup-boost --source-dir=$(pwd)
 
-    - name: Build a Boost distribution using B2
-      run: |
-        python3 tools/ci.py build-b2-distro \
-          --toolset ${{ matrix.toolset }}
+  #   - name: Build a Boost distribution using B2
+  #     run: |
+  #       python3 tools/ci.py build-b2-distro \
+  #         --toolset ${{ matrix.toolset }}
 
-    # No Redis server is available on this job, so integration tests are skipped.
-    # Unit tests are built and run via the CMake superproject build.
-    # Double backslash '//' prevents MSYS from interpreting flags as paths
-    - name: Build a Boost distribution and run the tests using CMake
-      run: |
-        python3 tools/ci.py build-cmake-distro \
-          --build-type ${{ matrix.build-type }} \
-          --cxxstd ${{ matrix.cxxstd }} \
-          --toolset ${{ matrix.toolset }} \
-          --generator "${{ matrix.generator }}" \
-          --build-shared-libs ${{ matrix.build-shared-libs }} \
-          --integration-tests 0 \
-          "--cxxflags=//WX"
+  #   # No Redis server is available on this job, so integration tests are skipped.
+  #   # Unit tests are built and run via the CMake superproject build.
+  #   # Double backslash '//' prevents MSYS from interpreting flags as paths
+  #   - name: Build a Boost distribution and run the tests using CMake
+  #     run: |
+  #       python3 tools/ci.py build-cmake-distro \
+  #         --build-type ${{ matrix.build-type }} \
+  #         --cxxstd ${{ matrix.cxxstd }} \
+  #         --toolset ${{ matrix.toolset }} \
+  #         --generator "${{ matrix.generator }}" \
+  #         --build-shared-libs ${{ matrix.build-shared-libs }} \
+  #         --integration-tests 0 \
+  #         "--cxxflags=//WX"
 
-    - name: Run add_subdirectory tests
-      run: |
-        python3 tools/ci.py run-cmake-add-subdirectory-tests \
-          --build-type ${{ matrix.build-type }} \
-          --cxxstd ${{ matrix.cxxstd }} \
-          --toolset ${{ matrix.toolset }} \
-          --generator "${{ matrix.generator }}" \
-          --build-shared-libs ${{ matrix.build-shared-libs }} \
-          "--cxxflags=//WX"
+  #   - name: Run add_subdirectory tests
+  #     run: |
+  #       python3 tools/ci.py run-cmake-add-subdirectory-tests \
+  #         --build-type ${{ matrix.build-type }} \
+  #         --cxxstd ${{ matrix.cxxstd }} \
+  #         --toolset ${{ matrix.toolset }} \
+  #         --generator "${{ matrix.generator }}" \
+  #         --build-shared-libs ${{ matrix.build-shared-libs }} \
+  #         "--cxxflags=//WX"
 
-    - name: Run find_package tests with the built cmake distribution
-      run: |
-        python3 tools/ci.py run-cmake-find-package-tests \
-          --build-type ${{ matrix.build-type }} \
-          --cxxstd ${{ matrix.cxxstd }} \
-          --toolset ${{ matrix.toolset }} \
-          --generator "${{ matrix.generator }}" \
-          --build-shared-libs ${{ matrix.build-shared-libs }} \
-          "--cxxflags=//WX"
+  #   - name: Run find_package tests with the built cmake distribution
+  #     run: |
+  #       python3 tools/ci.py run-cmake-find-package-tests \
+  #         --build-type ${{ matrix.build-type }} \
+  #         --cxxstd ${{ matrix.cxxstd }} \
+  #         --toolset ${{ matrix.toolset }} \
+  #         --generator "${{ matrix.generator }}" \
+  #         --build-shared-libs ${{ matrix.build-shared-libs }} \
+  #         "--cxxflags=//WX"
 
-    - name: Run find_package tests with the built b2 distribution
-      run: |
-        python3 tools/ci.py run-cmake-b2-find-package-tests \
-          --build-type ${{ matrix.build-type }} \
-          --cxxstd ${{ matrix.cxxstd }} \
-          --toolset ${{ matrix.toolset }} \
-          --generator "${{ matrix.generator }}" \
-          --build-shared-libs ${{ matrix.build-shared-libs }} \
-          "--cxxflags=//WX"
+  #   - name: Run find_package tests with the built b2 distribution
+  #     run: |
+  #       python3 tools/ci.py run-cmake-b2-find-package-tests \
+  #         --build-type ${{ matrix.build-type }} \
+  #         --cxxstd ${{ matrix.cxxstd }} \
+  #         --toolset ${{ matrix.toolset }} \
+  #         --generator "${{ matrix.generator }}" \
+  #         --build-shared-libs ${{ matrix.build-shared-libs }} \
+  #         "--cxxflags=//WX"
 
   windows-b2:
     name: "B2 ${{matrix.toolset}}"
@@ -93,8 +93,6 @@ jobs:
         include:
           #- { toolset: msvc-14.2, os: windows-2019 }
           - { toolset: msvc-14.3, os: windows-2022 }
-    env:
-      OPENSSL_ROOT: "C:\\Program Files\\OpenSSL"
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -112,400 +110,400 @@ jobs:
           --cxxstd 17,20 \
           --variant debug,release
 
-  posix-cmake:
-    name: "CMake ${{ matrix.toolset }} ${{ matrix.cxxstd }} ${{ matrix.build-type }} ${{ matrix.cxxflags }}"
-    defaults:
-      run:
-        shell: bash
+  # posix-cmake:
+  #   name: "CMake ${{ matrix.toolset }} ${{ matrix.cxxstd }} ${{ matrix.build-type }} ${{ matrix.cxxflags }}"
+  #   defaults:
+  #     run:
+  #       shell: bash
 
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # gcc-11 is the default in Ubuntu 22.04, defaults to c++17
-          - toolset: gcc-11
-            install: g++-11
-            container: ubuntu:22.04
-            cxxstd: '17'
-            build-type: 'Debug'
-            server: "redis:8.2.1-alpine"
-            corosio-tests: '0'
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         # gcc-11 is the default in Ubuntu 22.04, defaults to c++17
+  #         - toolset: gcc-11
+  #           install: g++-11
+  #           container: ubuntu:22.04
+  #           cxxstd: '17'
+  #           build-type: 'Debug'
+  #           server: "redis:8.2.1-alpine"
+  #           corosio-tests: '0'
 
-          - toolset: gcc-11
-            install: g++-11
-            container: ubuntu:22.04
-            cxxstd: '20'
-            build-type: 'Debug'
-            server: "valkey/valkey:8.1.3-alpine"
-            corosio-tests: '0'
+  #         - toolset: gcc-11
+  #           install: g++-11
+  #           container: ubuntu:22.04
+  #           cxxstd: '20'
+  #           build-type: 'Debug'
+  #           server: "valkey/valkey:8.1.3-alpine"
+  #           corosio-tests: '0'
 
-          - toolset: gcc-11
-            install: g++-11
-            container: ubuntu:22.04
-            cxxstd: '20'
-            build-type: 'Release'
-            server: "redis:7.4.5-alpine"
-            corosio-tests: '0'
+  #         - toolset: gcc-11
+  #           install: g++-11
+  #           container: ubuntu:22.04
+  #           cxxstd: '20'
+  #           build-type: 'Release'
+  #           server: "redis:7.4.5-alpine"
+  #           corosio-tests: '0'
 
-          - toolset: gcc-12
-            install: g++-12
-            container: ubuntu:22.04
-            cxxstd: '23'
-            build-type: 'Debug'
-            server: "redis:8.2.1-alpine"
+  #         - toolset: gcc-12
+  #           install: g++-12
+  #           container: ubuntu:22.04
+  #           cxxstd: '23'
+  #           build-type: 'Debug'
+  #           server: "redis:8.2.1-alpine"
 
-          # gcc-13 is the default in Ubuntu 24.04, defaults to c++17
-          - toolset: gcc-13
-            install: g++-13
-            container: ubuntu:24.04
-            cxxstd: '17'
-            build-type: 'Debug'
-            server: "valkey/valkey:8.1.3-alpine"
-            corosio-tests: '0'
+  #         # gcc-13 is the default in Ubuntu 24.04, defaults to c++17
+  #         - toolset: gcc-13
+  #           install: g++-13
+  #           container: ubuntu:24.04
+  #           cxxstd: '17'
+  #           build-type: 'Debug'
+  #           server: "valkey/valkey:8.1.3-alpine"
+  #           corosio-tests: '0'
 
-          - toolset: gcc-13
-            install: g++-13
-            container: ubuntu:24.04
-            cxxstd: '23'
-            build-type: 'Debug'
-            server: "redis:7.4.5-alpine"
+  #         - toolset: gcc-13
+  #           install: g++-13
+  #           container: ubuntu:24.04
+  #           cxxstd: '23'
+  #           build-type: 'Debug'
+  #           server: "redis:7.4.5-alpine"
 
-          - toolset: gcc-13
-            install: g++-13
-            container: ubuntu:24.04
-            cxxstd: '23'
-            build-type: 'Release'
-            server: "redis:8.2.1-alpine"
+  #         - toolset: gcc-13
+  #           install: g++-13
+  #           container: ubuntu:24.04
+  #           cxxstd: '23'
+  #           build-type: 'Release'
+  #           server: "redis:8.2.1-alpine"
 
-          - toolset: gcc-14
-            install: g++-14
-            container: ubuntu:24.04
-            cxxstd: '23'
-            build-type: 'Debug'
-            server: "valkey/valkey:8.1.3-alpine"
+  #         - toolset: gcc-14
+  #           install: g++-14
+  #           container: ubuntu:24.04
+  #           cxxstd: '23'
+  #           build-type: 'Debug'
+  #           server: "valkey/valkey:8.1.3-alpine"
 
-          # gcc-15 is the default in Ubuntu 26.04, defaults to c++17
-          - toolset: gcc-15
-            install: g++-15
-            container: ubuntu:26.04
-            cxxstd: '17'
-            build-type: 'Debug'
-            server: "redis:7.4.5-alpine"
-            corosio-tests: '0'
+  #         # gcc-15 is the default in Ubuntu 26.04, defaults to c++17
+  #         - toolset: gcc-15
+  #           install: g++-15
+  #           container: ubuntu:26.04
+  #           cxxstd: '17'
+  #           build-type: 'Debug'
+  #           server: "redis:7.4.5-alpine"
+  #           corosio-tests: '0'
 
-          - toolset: gcc-15
-            install: g++-15
-            container: ubuntu:26.04
-            cxxstd: '26'
-            build-type: 'Debug'
-            cxxflags: '-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all'
-            ldflags: '-fsanitize=address -fsanitize=undefined'
-            server: "valkey/valkey:8.1.3-alpine"
+  #         - toolset: gcc-15
+  #           install: g++-15
+  #           container: ubuntu:26.04
+  #           cxxstd: '26'
+  #           build-type: 'Debug'
+  #           cxxflags: '-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all'
+  #           ldflags: '-fsanitize=address -fsanitize=undefined'
+  #           server: "valkey/valkey:8.1.3-alpine"
 
-          - toolset: gcc-15
-            install: g++-15
-            container: ubuntu:26.04
-            cxxstd: '26'
-            build-type: 'Release'
-            server: "redis:7.4.5-alpine"
+  #         - toolset: gcc-15
+  #           install: g++-15
+  #           container: ubuntu:26.04
+  #           cxxstd: '26'
+  #           build-type: 'Release'
+  #           server: "redis:7.4.5-alpine"
 
-          - toolset: clang-11
-            install: clang-11
-            container: ubuntu:22.04
-            cxxstd: '20'
-            build-type: 'Debug'
-            server: "redis:7.4.5-alpine"
-            corosio-tests: '0'
+  #         - toolset: clang-11
+  #           install: clang-11
+  #           container: ubuntu:22.04
+  #           cxxstd: '20'
+  #           build-type: 'Debug'
+  #           server: "redis:7.4.5-alpine"
+  #           corosio-tests: '0'
 
-          - toolset: clang-12
-            install: clang-12
-            container: ubuntu:22.04
-            cxxstd: '20'
-            build-type: 'Debug'
-            server: "redis:8.2.1-alpine"
-            corosio-tests: '0'
+  #         - toolset: clang-12
+  #           install: clang-12
+  #           container: ubuntu:22.04
+  #           cxxstd: '20'
+  #           build-type: 'Debug'
+  #           server: "redis:8.2.1-alpine"
+  #           corosio-tests: '0'
 
-          - toolset: clang-13
-            install: clang-13
-            container: ubuntu:22.04
-            cxxstd: '20'
-            build-type: 'Debug'
-            server: "valkey/valkey:8.1.3-alpine"
-            corosio-tests: '0'
+  #         - toolset: clang-13
+  #           install: clang-13
+  #           container: ubuntu:22.04
+  #           cxxstd: '20'
+  #           build-type: 'Debug'
+  #           server: "valkey/valkey:8.1.3-alpine"
+  #           corosio-tests: '0'
 
-          # clang-14 is the default in Ubuntu 22.04
-          - toolset: clang-14
-            install: clang-14
-            container: ubuntu:22.04
-            cxxstd: '20'
-            build-type: 'Debug'
-            server: "redis:7.4.5-alpine"
-            corosio-tests: '0'
+  #         # clang-14 is the default in Ubuntu 22.04
+  #         - toolset: clang-14
+  #           install: clang-14
+  #           container: ubuntu:22.04
+  #           cxxstd: '20'
+  #           build-type: 'Debug'
+  #           server: "redis:7.4.5-alpine"
+  #           corosio-tests: '0'
 
-          - toolset: clang-14
-            install: 'clang-14 libc++-14-dev libc++abi-14-dev'
-            container: ubuntu:22.04
-            cxxstd: '20'
-            build-type: 'Debug'
-            cxxflags: '-stdlib=libc++'
-            ldflags: '-lc++'
-            server: "redis:8.2.1-alpine"
-            corosio-tests: '0'
+  #         - toolset: clang-14
+  #           install: 'clang-14 libc++-14-dev libc++abi-14-dev'
+  #           container: ubuntu:22.04
+  #           cxxstd: '20'
+  #           build-type: 'Debug'
+  #           cxxflags: '-stdlib=libc++'
+  #           ldflags: '-lc++'
+  #           server: "redis:8.2.1-alpine"
+  #           corosio-tests: '0'
 
-          - toolset: clang-14
-            install: 'clang-14 libc++-14-dev libc++abi-14-dev'
-            container: ubuntu:22.04
-            cxxstd: '20'
-            build-type: 'Release'
-            cxxflags: '-stdlib=libc++'
-            ldflags: '-lc++'
-            server: "valkey/valkey:8.1.3-alpine"
+  #         - toolset: clang-14
+  #           install: 'clang-14 libc++-14-dev libc++abi-14-dev'
+  #           container: ubuntu:22.04
+  #           cxxstd: '20'
+  #           build-type: 'Release'
+  #           cxxflags: '-stdlib=libc++'
+  #           ldflags: '-lc++'
+  #           server: "valkey/valkey:8.1.3-alpine"
 
-          - toolset: clang-15
-            install: clang-15
-            container: ubuntu:22.04
-            cxxstd: '20'
-            build-type: 'Debug'
-            server: "redis:7.4.5-alpine"
-            corosio-tests: '0'
+  #         - toolset: clang-15
+  #           install: clang-15
+  #           container: ubuntu:22.04
+  #           cxxstd: '20'
+  #           build-type: 'Debug'
+  #           server: "redis:7.4.5-alpine"
+  #           corosio-tests: '0'
 
-          - toolset: clang-16
-            install: clang-16
-            container: ubuntu:24.04
-            cxxstd: '20'
-            build-type: 'Debug'
-            cxxflags: '-DBOOST_ASIO_DISABLE_LOCAL_SOCKETS=1' # If a system has no UNIX socket support, we build correctly
-            server: "redis:8.2.1-alpine"
-            corosio-tests: '0'
+  #         - toolset: clang-16
+  #           install: clang-16
+  #           container: ubuntu:24.04
+  #           cxxstd: '20'
+  #           build-type: 'Debug'
+  #           cxxflags: '-DBOOST_ASIO_DISABLE_LOCAL_SOCKETS=1' # If a system has no UNIX socket support, we build correctly
+  #           server: "redis:8.2.1-alpine"
+  #           corosio-tests: '0'
 
-          - toolset: clang-17
-            install: clang-17
-            container: ubuntu:24.04
-            cxxstd: '20'
-            build-type: 'Debug'
-            server: "valkey/valkey:8.1.3-alpine"
+  #         - toolset: clang-17
+  #           install: clang-17
+  #           container: ubuntu:24.04
+  #           cxxstd: '20'
+  #           build-type: 'Debug'
+  #           server: "valkey/valkey:8.1.3-alpine"
 
-          # clang-18 is the default in Ubuntu 24.04
-          - toolset: clang-18
-            install: clang-18
-            container: ubuntu:24.04
-            cxxstd: '20'
-            build-type: 'Debug'
-            server: "redis:7.4.5-alpine"
+  #         # clang-18 is the default in Ubuntu 24.04
+  #         - toolset: clang-18
+  #           install: clang-18
+  #           container: ubuntu:24.04
+  #           cxxstd: '20'
+  #           build-type: 'Debug'
+  #           server: "redis:7.4.5-alpine"
 
-          - toolset: clang-18
-            install: 'clang-18 libc++-18-dev libc++abi-18-dev'
-            container: ubuntu:24.04
-            cxxstd: '20'
-            build-type: 'Release'
-            cxxflags: '-stdlib=libc++'
-            ldflags: '-lc++'
-            server: "valkey/valkey:8.1.3-alpine"
+  #         - toolset: clang-18
+  #           install: 'clang-18 libc++-18-dev libc++abi-18-dev'
+  #           container: ubuntu:24.04
+  #           cxxstd: '20'
+  #           build-type: 'Release'
+  #           cxxflags: '-stdlib=libc++'
+  #           ldflags: '-lc++'
+  #           server: "valkey/valkey:8.1.3-alpine"
 
-          - toolset: clang-18
-            install: 'clang-18 libc++-18-dev libc++abi-18-dev'
-            container: ubuntu:24.04
-            cxxstd: '23'
-            build-type: 'Debug'
-            cxxflags: '-stdlib=libc++'
-            ldflags: '-lc++'
-            server: "redis:8.2.1-alpine"
+  #         - toolset: clang-18
+  #           install: 'clang-18 libc++-18-dev libc++abi-18-dev'
+  #           container: ubuntu:24.04
+  #           cxxstd: '23'
+  #           build-type: 'Debug'
+  #           cxxflags: '-stdlib=libc++'
+  #           ldflags: '-lc++'
+  #           server: "redis:8.2.1-alpine"
 
-          - toolset: clang-19
-            install: clang-19
-            container: ubuntu:24.04
-            cxxstd: '23'
-            build-type: 'Debug'
-            server: "redis:7.4.5-alpine"
+  #         - toolset: clang-19
+  #           install: clang-19
+  #           container: ubuntu:24.04
+  #           cxxstd: '23'
+  #           build-type: 'Debug'
+  #           server: "redis:7.4.5-alpine"
 
-          - toolset: clang-20
-            install: clang-20
-            container: ubuntu:24.04
-            cxxstd: '23'
-            build-type: 'Debug'
-            server: "redis:8.2.1-alpine"
+  #         - toolset: clang-20
+  #           install: clang-20
+  #           container: ubuntu:24.04
+  #           cxxstd: '23'
+  #           build-type: 'Debug'
+  #           server: "redis:8.2.1-alpine"
 
-          # clang-21 is the default in Ubuntu 26.04
-          - toolset: clang-21
-            install: 'clang-21 libclang-rt-21-dev'
-            container: ubuntu:26.04
-            cxxstd: '23'
-            build-type: 'Debug'
-            cxxflags: '-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all'
-            ldflags: '-fsanitize=address -fsanitize=undefined'
-            server: "valkey/valkey:8.1.3-alpine"
+  #         # clang-21 is the default in Ubuntu 26.04
+  #         - toolset: clang-21
+  #           install: 'clang-21 libclang-rt-21-dev'
+  #           container: ubuntu:26.04
+  #           cxxstd: '23'
+  #           build-type: 'Debug'
+  #           cxxflags: '-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all'
+  #           ldflags: '-fsanitize=address -fsanitize=undefined'
+  #           server: "valkey/valkey:8.1.3-alpine"
 
-          - toolset: clang-21
-            install: 'clang-21 libc++-21-dev libc++abi-21-dev'
-            container: ubuntu:26.04
-            cxxstd: '23'
-            build-type: 'Debug'
-            cxxflags: '-stdlib=libc++'
-            ldflags: '-lc++'
-            server: "redis:7.4.5-alpine"
+  #         - toolset: clang-21
+  #           install: 'clang-21 libc++-21-dev libc++abi-21-dev'
+  #           container: ubuntu:26.04
+  #           cxxstd: '23'
+  #           build-type: 'Debug'
+  #           cxxflags: '-stdlib=libc++'
+  #           ldflags: '-lc++'
+  #           server: "redis:7.4.5-alpine"
 
-          - toolset: clang-21
-            install: 'clang-21 libc++-21-dev libc++abi-21-dev'
-            container: ubuntu:26.04
-            cxxstd: '23'
-            build-type: 'Release'
-            cxxflags: '-stdlib=libc++'
-            ldflags: '-lc++'
-            server: "redis:8.2.1-alpine"
+  #         - toolset: clang-21
+  #           install: 'clang-21 libc++-21-dev libc++abi-21-dev'
+  #           container: ubuntu:26.04
+  #           cxxstd: '23'
+  #           build-type: 'Release'
+  #           cxxflags: '-stdlib=libc++'
+  #           ldflags: '-lc++'
+  #           server: "redis:8.2.1-alpine"
 
-          - toolset: clang-22
-            install: clang-22
-            container: ubuntu:26.04
-            cxxstd: '23'
-            build-type: 'Debug'
-            server: "valkey/valkey:8.1.3-alpine"
+  #         - toolset: clang-22
+  #           install: clang-22
+  #           container: ubuntu:26.04
+  #           cxxstd: '23'
+  #           build-type: 'Debug'
+  #           server: "valkey/valkey:8.1.3-alpine"
 
-    runs-on: ubuntu-latest
+  #   runs-on: ubuntu-latest
     
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v6
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v6
     
-    - name: Generate TLS certificates
-      run: |
-        ./tools/gen-certificates.sh
+  #   - name: Generate TLS certificates
+  #     run: |
+  #       ./tools/gen-certificates.sh
     
-    - name: Set up the required containers
-      run: |
-        BUILDER_IMAGE=${{ matrix.container }} SERVER_IMAGE=${{ matrix.server }} docker compose -f tools/docker-compose.yml up -d --wait || (docker compose logs; exit 1)
+  #   - name: Set up the required containers
+  #     run: |
+  #       BUILDER_IMAGE=${{ matrix.container }} SERVER_IMAGE=${{ matrix.server }} docker compose -f tools/docker-compose.yml up -d --wait || (docker compose logs; exit 1)
       
-    - name: Install dependencies
-      run: |
-        docker exec builder apt-get update
-        docker exec --env DEBIAN_FRONTEND=noninteractive builder apt-get -y --no-install-recommends install \
-          git \
-          g++ \
-          libssl-dev \
-          make \
-          ca-certificates \
-          cmake \
-          protobuf-compiler \
-          python3 \
-          ${{ matrix.install }}
+  #   - name: Install dependencies
+  #     run: |
+  #       docker exec builder apt-get update
+  #       docker exec --env DEBIAN_FRONTEND=noninteractive builder apt-get -y --no-install-recommends install \
+  #         git \
+  #         g++ \
+  #         libssl-dev \
+  #         make \
+  #         ca-certificates \
+  #         cmake \
+  #         protobuf-compiler \
+  #         python3 \
+  #         ${{ matrix.install }}
 
-    - name: Setup Boost
-      run: docker exec builder /boost-redis/tools/ci.py setup-boost --source-dir=/boost-redis
+  #   - name: Setup Boost
+  #     run: docker exec builder /boost-redis/tools/ci.py setup-boost --source-dir=/boost-redis
 
-    - name: Build a Boost distribution using B2
-      run: |
-        docker exec builder /boost-redis/tools/ci.py build-b2-distro \
-          --toolset ${{ matrix.toolset }}
+  #   - name: Build a Boost distribution using B2
+  #     run: |
+  #       docker exec builder /boost-redis/tools/ci.py build-b2-distro \
+  #         --toolset ${{ matrix.toolset }}
 
-    # The CMake superproject build also drives the project tests, including
-    # integration tests against the Redis server set up above.
-    - name: Build a Boost distribution and run the tests using CMake
-      run: |
-        docker exec builder /boost-redis/tools/ci.py build-cmake-distro \
-          --build-type ${{ matrix.build-type }} \
-          --cxxstd ${{ matrix.cxxstd }} \
-          --toolset ${{ matrix.toolset }} \
-          "--cxxflags=${{ matrix.cxxflags }} -Werror" \
-          "--ldflags=${{ matrix.ldflags }}"
+  #   # The CMake superproject build also drives the project tests, including
+  #   # integration tests against the Redis server set up above.
+  #   - name: Build a Boost distribution and run the tests using CMake
+  #     run: |
+  #       docker exec builder /boost-redis/tools/ci.py build-cmake-distro \
+  #         --build-type ${{ matrix.build-type }} \
+  #         --cxxstd ${{ matrix.cxxstd }} \
+  #         --toolset ${{ matrix.toolset }} \
+  #         "--cxxflags=${{ matrix.cxxflags }} -Werror" \
+  #         "--ldflags=${{ matrix.ldflags }}"
 
-    - name: Run add_subdirectory tests
-      run: |
-        docker exec builder /boost-redis/tools/ci.py run-cmake-add-subdirectory-tests \
-          --build-type ${{ matrix.build-type }} \
-          --cxxstd ${{ matrix.cxxstd }} \
-          --toolset ${{ matrix.toolset }} \
-          "--cxxflags=${{ matrix.cxxflags }} -Werror" \
-          "--ldflags=${{ matrix.ldflags }}"
+  #   - name: Run add_subdirectory tests
+  #     run: |
+  #       docker exec builder /boost-redis/tools/ci.py run-cmake-add-subdirectory-tests \
+  #         --build-type ${{ matrix.build-type }} \
+  #         --cxxstd ${{ matrix.cxxstd }} \
+  #         --toolset ${{ matrix.toolset }} \
+  #         "--cxxflags=${{ matrix.cxxflags }} -Werror" \
+  #         "--ldflags=${{ matrix.ldflags }}"
 
-    - name: Run find_package tests with the built cmake distribution
-      run: |
-        docker exec builder /boost-redis/tools/ci.py run-cmake-find-package-tests \
-          --build-type ${{ matrix.build-type }} \
-          --cxxstd ${{ matrix.cxxstd }} \
-          --toolset ${{ matrix.toolset }} \
-          "--cxxflags=${{ matrix.cxxflags }} -Werror" \
-          "--ldflags=${{ matrix.ldflags }}"
+  #   - name: Run find_package tests with the built cmake distribution
+  #     run: |
+  #       docker exec builder /boost-redis/tools/ci.py run-cmake-find-package-tests \
+  #         --build-type ${{ matrix.build-type }} \
+  #         --cxxstd ${{ matrix.cxxstd }} \
+  #         --toolset ${{ matrix.toolset }} \
+  #         "--cxxflags=${{ matrix.cxxflags }} -Werror" \
+  #         "--ldflags=${{ matrix.ldflags }}"
 
-    - name: Run find_package tests with the built b2 distribution
-      run: |
-        docker exec builder /boost-redis/tools/ci.py run-cmake-b2-find-package-tests \
-          --build-type ${{ matrix.build-type }} \
-          --cxxstd ${{ matrix.cxxstd }} \
-          --toolset ${{ matrix.toolset }} \
-          "--cxxflags=${{ matrix.cxxflags }} -Werror" \
-          "--ldflags=${{ matrix.ldflags }}"
+  #   - name: Run find_package tests with the built b2 distribution
+  #     run: |
+  #       docker exec builder /boost-redis/tools/ci.py run-cmake-b2-find-package-tests \
+  #         --build-type ${{ matrix.build-type }} \
+  #         --cxxstd ${{ matrix.cxxstd }} \
+  #         --toolset ${{ matrix.toolset }} \
+  #         "--cxxflags=${{ matrix.cxxflags }} -Werror" \
+  #         "--ldflags=${{ matrix.ldflags }}"
 
-  posix-b2:
-    name: "B2 ${{ matrix.toolset }}"
-    defaults:
-      run:
-        shell: bash
+  # posix-b2:
+  #   name: "B2 ${{ matrix.toolset }}"
+  #   defaults:
+  #     run:
+  #       shell: bash
 
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # We don't have integration tests here, so we only test the compilers
-          # that get installed by default in Ubuntu 22.04, 24.04 and 26.04
-          - toolset: gcc-11
-            install: g++-11
-            cxxstd: "11,17,20" # Having C++11 shouldn't break the build
-            container: ubuntu:22.04
-          - toolset: gcc-13
-            install: g++-13
-            cxxstd: "17,20,23"
-            container: ubuntu:24.04
-          - toolset: gcc-15
-            install: g++-15
-            cxxstd: "17,20,23"
-            container: ubuntu:26.04
-          - toolset: clang-18
-            install: clang-18
-            cxxstd: "11,17,20"
-            container: ubuntu:24.04
-          - toolset: clang-21
-            install: clang-21
-            cxxstd: "17,20,23"
-            container: ubuntu:26.04
-    runs-on: ubuntu-latest
-    container: ${{matrix.container}}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v6
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         # We don't have integration tests here, so we only test the compilers
+  #         # that get installed by default in Ubuntu 22.04, 24.04 and 26.04
+  #         - toolset: gcc-11
+  #           install: g++-11
+  #           cxxstd: "11,17,20" # Having C++11 shouldn't break the build
+  #           container: ubuntu:22.04
+  #         - toolset: gcc-13
+  #           install: g++-13
+  #           cxxstd: "17,20,23"
+  #           container: ubuntu:24.04
+  #         - toolset: gcc-15
+  #           install: g++-15
+  #           cxxstd: "17,20,23"
+  #           container: ubuntu:26.04
+  #         - toolset: clang-18
+  #           install: clang-18
+  #           cxxstd: "11,17,20"
+  #           container: ubuntu:24.04
+  #         - toolset: clang-21
+  #           install: clang-21
+  #           cxxstd: "17,20,23"
+  #           container: ubuntu:26.04
+  #   runs-on: ubuntu-latest
+  #   container: ${{matrix.container}}
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v6
 
-    - name: Setup container environment
-      if: matrix.container
-      run: |
-        export DEBIAN_FRONTEND=noninteractive
-        apt-get update
-        apt-get -y install python3 git g++ libssl-dev ${{ matrix.install }}
+  #   - name: Setup container environment
+  #     if: matrix.container
+  #     run: |
+  #       export DEBIAN_FRONTEND=noninteractive
+  #       apt-get update
+  #       apt-get -y install python3 git g++ libssl-dev ${{ matrix.install }}
 
-    - name: Setup Boost
-      run: ./tools/ci.py setup-boost --source-dir=$(pwd)
+  #   - name: Setup Boost
+  #     run: ./tools/ci.py setup-boost --source-dir=$(pwd)
     
-    - name: Build and run project tests using B2
-      run: |
-        python3 tools/ci.py run-b2-tests \
-          --toolset ${{ matrix.toolset }} \
-          --cxxstd ${{ matrix.cxxstd }} \
-          --variant debug,release
+  #   - name: Build and run project tests using B2
+  #     run: |
+  #       python3 tools/ci.py run-b2-tests \
+  #         --toolset ${{ matrix.toolset }} \
+  #         --cxxstd ${{ matrix.cxxstd }} \
+  #         --variant debug,release
 
-  # Checks that we don't have any errors in docs
-  check-docs:
-    name: Check docs
-    defaults:
-      run:
-        shell: bash
+  # # Checks that we don't have any errors in docs
+  # check-docs:
+  #   name: Check docs
+  #   defaults:
+  #     run:
+  #       shell: bash
 
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v6
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v6
 
-    - name: Setup Boost
-      run: ./tools/ci.py setup-boost --source-dir=$(pwd)
+  #   - name: Setup Boost
+  #     run: ./tools/ci.py setup-boost --source-dir=$(pwd)
     
-    - name: Build docs
-      run: |
-        cd ~/boost-root
-        ./b2 libs/redis/doc
-        [ -f ~/boost-root/libs/redis/doc/html/index.html ]
+  #   - name: Build docs
+  #     run: |
+  #       cd ~/boost-root
+  #       ./b2 libs/redis/doc
+  #       [ -f ~/boost-root/libs/redis/doc/html/index.html ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,75 +11,75 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  # windows-cmake:
-  #   name: "CMake ${{matrix.toolset}} ${{matrix.build-type}} C++${{matrix.cxxstd}}"
-  #   runs-on: ${{matrix.os}}
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         #- { toolset: msvc-14.2, os: windows-2019, generator: "Visual Studio 16 2019", cxxstd: '17', build-type: 'Debug',   build-shared-libs: 1 }
-  #         #- { toolset: msvc-14.2, os: windows-2019, generator: "Visual Studio 16 2019", cxxstd: '17', build-type: 'Release', build-shared-libs: 0 }
-  #         - { toolset: msvc-14.3, os: windows-2022, generator: "Visual Studio 17 2022", cxxstd: '20', build-type: 'Debug',   build-shared-libs: 0 }
-  #         - { toolset: msvc-14.3, os: windows-2022, generator: "Visual Studio 17 2022", cxxstd: '20', build-type: 'Release', build-shared-libs: 1 }
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v6
+  windows-cmake:
+    name: "CMake ${{matrix.toolset}} ${{matrix.build-type}} C++${{matrix.cxxstd}}"
+    runs-on: ${{matrix.os}}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          #- { toolset: msvc-14.2, os: windows-2019, generator: "Visual Studio 16 2019", cxxstd: '17', build-type: 'Debug',   build-shared-libs: 1 }
+          #- { toolset: msvc-14.2, os: windows-2019, generator: "Visual Studio 16 2019", cxxstd: '17', build-type: 'Release', build-shared-libs: 0 }
+          - { toolset: msvc-14.3, os: windows-2022, generator: "Visual Studio 17 2022", cxxstd: '20', build-type: 'Debug',   build-shared-libs: 0 }
+          - { toolset: msvc-14.3, os: windows-2022, generator: "Visual Studio 17 2022", cxxstd: '20', build-type: 'Release', build-shared-libs: 1 }
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
 
-  #   - name: Setup Boost
-  #     run: python3 tools/ci.py setup-boost --source-dir=$(pwd)
+    - name: Setup Boost
+      run: python3 tools/ci.py setup-boost --source-dir=$(pwd)
 
-  #   - name: Build a Boost distribution using B2
-  #     run: |
-  #       python3 tools/ci.py build-b2-distro \
-  #         --toolset ${{ matrix.toolset }}
+    - name: Build a Boost distribution using B2
+      run: |
+        python3 tools/ci.py build-b2-distro \
+          --toolset ${{ matrix.toolset }}
 
-  #   # No Redis server is available on this job, so integration tests are skipped.
-  #   # Unit tests are built and run via the CMake superproject build.
-  #   # Double backslash '//' prevents MSYS from interpreting flags as paths
-  #   - name: Build a Boost distribution and run the tests using CMake
-  #     run: |
-  #       python3 tools/ci.py build-cmake-distro \
-  #         --build-type ${{ matrix.build-type }} \
-  #         --cxxstd ${{ matrix.cxxstd }} \
-  #         --toolset ${{ matrix.toolset }} \
-  #         --generator "${{ matrix.generator }}" \
-  #         --build-shared-libs ${{ matrix.build-shared-libs }} \
-  #         --integration-tests 0 \
-  #         "--cxxflags=//WX"
+    # No Redis server is available on this job, so integration tests are skipped.
+    # Unit tests are built and run via the CMake superproject build.
+    # Double backslash '//' prevents MSYS from interpreting flags as paths
+    - name: Build a Boost distribution and run the tests using CMake
+      run: |
+        python3 tools/ci.py build-cmake-distro \
+          --build-type ${{ matrix.build-type }} \
+          --cxxstd ${{ matrix.cxxstd }} \
+          --toolset ${{ matrix.toolset }} \
+          --generator "${{ matrix.generator }}" \
+          --build-shared-libs ${{ matrix.build-shared-libs }} \
+          --integration-tests 0 \
+          "--cxxflags=//WX"
 
-  #   - name: Run add_subdirectory tests
-  #     run: |
-  #       python3 tools/ci.py run-cmake-add-subdirectory-tests \
-  #         --build-type ${{ matrix.build-type }} \
-  #         --cxxstd ${{ matrix.cxxstd }} \
-  #         --toolset ${{ matrix.toolset }} \
-  #         --generator "${{ matrix.generator }}" \
-  #         --build-shared-libs ${{ matrix.build-shared-libs }} \
-  #         "--cxxflags=//WX"
+    - name: Run add_subdirectory tests
+      run: |
+        python3 tools/ci.py run-cmake-add-subdirectory-tests \
+          --build-type ${{ matrix.build-type }} \
+          --cxxstd ${{ matrix.cxxstd }} \
+          --toolset ${{ matrix.toolset }} \
+          --generator "${{ matrix.generator }}" \
+          --build-shared-libs ${{ matrix.build-shared-libs }} \
+          "--cxxflags=//WX"
 
-  #   - name: Run find_package tests with the built cmake distribution
-  #     run: |
-  #       python3 tools/ci.py run-cmake-find-package-tests \
-  #         --build-type ${{ matrix.build-type }} \
-  #         --cxxstd ${{ matrix.cxxstd }} \
-  #         --toolset ${{ matrix.toolset }} \
-  #         --generator "${{ matrix.generator }}" \
-  #         --build-shared-libs ${{ matrix.build-shared-libs }} \
-  #         "--cxxflags=//WX"
+    - name: Run find_package tests with the built cmake distribution
+      run: |
+        python3 tools/ci.py run-cmake-find-package-tests \
+          --build-type ${{ matrix.build-type }} \
+          --cxxstd ${{ matrix.cxxstd }} \
+          --toolset ${{ matrix.toolset }} \
+          --generator "${{ matrix.generator }}" \
+          --build-shared-libs ${{ matrix.build-shared-libs }} \
+          "--cxxflags=//WX"
 
-  #   - name: Run find_package tests with the built b2 distribution
-  #     run: |
-  #       python3 tools/ci.py run-cmake-b2-find-package-tests \
-  #         --build-type ${{ matrix.build-type }} \
-  #         --cxxstd ${{ matrix.cxxstd }} \
-  #         --toolset ${{ matrix.toolset }} \
-  #         --generator "${{ matrix.generator }}" \
-  #         --build-shared-libs ${{ matrix.build-shared-libs }} \
-  #         "--cxxflags=//WX"
+    - name: Run find_package tests with the built b2 distribution
+      run: |
+        python3 tools/ci.py run-cmake-b2-find-package-tests \
+          --build-type ${{ matrix.build-type }} \
+          --cxxstd ${{ matrix.cxxstd }} \
+          --toolset ${{ matrix.toolset }} \
+          --generator "${{ matrix.generator }}" \
+          --build-shared-libs ${{ matrix.build-shared-libs }} \
+          "--cxxflags=//WX"
 
   windows-b2:
     name: "B2 ${{matrix.toolset}}"
@@ -110,400 +110,400 @@ jobs:
           --cxxstd 17,20 \
           --variant debug,release
 
-  # posix-cmake:
-  #   name: "CMake ${{ matrix.toolset }} ${{ matrix.cxxstd }} ${{ matrix.build-type }} ${{ matrix.cxxflags }}"
-  #   defaults:
-  #     run:
-  #       shell: bash
+  posix-cmake:
+    name: "CMake ${{ matrix.toolset }} ${{ matrix.cxxstd }} ${{ matrix.build-type }} ${{ matrix.cxxflags }}"
+    defaults:
+      run:
+        shell: bash
 
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         # gcc-11 is the default in Ubuntu 22.04, defaults to c++17
-  #         - toolset: gcc-11
-  #           install: g++-11
-  #           container: ubuntu:22.04
-  #           cxxstd: '17'
-  #           build-type: 'Debug'
-  #           server: "redis:8.2.1-alpine"
-  #           corosio-tests: '0'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # gcc-11 is the default in Ubuntu 22.04, defaults to c++17
+          - toolset: gcc-11
+            install: g++-11
+            container: ubuntu:22.04
+            cxxstd: '17'
+            build-type: 'Debug'
+            server: "redis:8.2.1-alpine"
+            corosio-tests: '0'
 
-  #         - toolset: gcc-11
-  #           install: g++-11
-  #           container: ubuntu:22.04
-  #           cxxstd: '20'
-  #           build-type: 'Debug'
-  #           server: "valkey/valkey:8.1.3-alpine"
-  #           corosio-tests: '0'
+          - toolset: gcc-11
+            install: g++-11
+            container: ubuntu:22.04
+            cxxstd: '20'
+            build-type: 'Debug'
+            server: "valkey/valkey:8.1.3-alpine"
+            corosio-tests: '0'
 
-  #         - toolset: gcc-11
-  #           install: g++-11
-  #           container: ubuntu:22.04
-  #           cxxstd: '20'
-  #           build-type: 'Release'
-  #           server: "redis:7.4.5-alpine"
-  #           corosio-tests: '0'
+          - toolset: gcc-11
+            install: g++-11
+            container: ubuntu:22.04
+            cxxstd: '20'
+            build-type: 'Release'
+            server: "redis:7.4.5-alpine"
+            corosio-tests: '0'
 
-  #         - toolset: gcc-12
-  #           install: g++-12
-  #           container: ubuntu:22.04
-  #           cxxstd: '23'
-  #           build-type: 'Debug'
-  #           server: "redis:8.2.1-alpine"
+          - toolset: gcc-12
+            install: g++-12
+            container: ubuntu:22.04
+            cxxstd: '23'
+            build-type: 'Debug'
+            server: "redis:8.2.1-alpine"
 
-  #         # gcc-13 is the default in Ubuntu 24.04, defaults to c++17
-  #         - toolset: gcc-13
-  #           install: g++-13
-  #           container: ubuntu:24.04
-  #           cxxstd: '17'
-  #           build-type: 'Debug'
-  #           server: "valkey/valkey:8.1.3-alpine"
-  #           corosio-tests: '0'
+          # gcc-13 is the default in Ubuntu 24.04, defaults to c++17
+          - toolset: gcc-13
+            install: g++-13
+            container: ubuntu:24.04
+            cxxstd: '17'
+            build-type: 'Debug'
+            server: "valkey/valkey:8.1.3-alpine"
+            corosio-tests: '0'
 
-  #         - toolset: gcc-13
-  #           install: g++-13
-  #           container: ubuntu:24.04
-  #           cxxstd: '23'
-  #           build-type: 'Debug'
-  #           server: "redis:7.4.5-alpine"
+          - toolset: gcc-13
+            install: g++-13
+            container: ubuntu:24.04
+            cxxstd: '23'
+            build-type: 'Debug'
+            server: "redis:7.4.5-alpine"
 
-  #         - toolset: gcc-13
-  #           install: g++-13
-  #           container: ubuntu:24.04
-  #           cxxstd: '23'
-  #           build-type: 'Release'
-  #           server: "redis:8.2.1-alpine"
+          - toolset: gcc-13
+            install: g++-13
+            container: ubuntu:24.04
+            cxxstd: '23'
+            build-type: 'Release'
+            server: "redis:8.2.1-alpine"
 
-  #         - toolset: gcc-14
-  #           install: g++-14
-  #           container: ubuntu:24.04
-  #           cxxstd: '23'
-  #           build-type: 'Debug'
-  #           server: "valkey/valkey:8.1.3-alpine"
+          - toolset: gcc-14
+            install: g++-14
+            container: ubuntu:24.04
+            cxxstd: '23'
+            build-type: 'Debug'
+            server: "valkey/valkey:8.1.3-alpine"
 
-  #         # gcc-15 is the default in Ubuntu 26.04, defaults to c++17
-  #         - toolset: gcc-15
-  #           install: g++-15
-  #           container: ubuntu:26.04
-  #           cxxstd: '17'
-  #           build-type: 'Debug'
-  #           server: "redis:7.4.5-alpine"
-  #           corosio-tests: '0'
+          # gcc-15 is the default in Ubuntu 26.04, defaults to c++17
+          - toolset: gcc-15
+            install: g++-15
+            container: ubuntu:26.04
+            cxxstd: '17'
+            build-type: 'Debug'
+            server: "redis:7.4.5-alpine"
+            corosio-tests: '0'
 
-  #         - toolset: gcc-15
-  #           install: g++-15
-  #           container: ubuntu:26.04
-  #           cxxstd: '26'
-  #           build-type: 'Debug'
-  #           cxxflags: '-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all'
-  #           ldflags: '-fsanitize=address -fsanitize=undefined'
-  #           server: "valkey/valkey:8.1.3-alpine"
+          - toolset: gcc-15
+            install: g++-15
+            container: ubuntu:26.04
+            cxxstd: '26'
+            build-type: 'Debug'
+            cxxflags: '-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all'
+            ldflags: '-fsanitize=address -fsanitize=undefined'
+            server: "valkey/valkey:8.1.3-alpine"
 
-  #         - toolset: gcc-15
-  #           install: g++-15
-  #           container: ubuntu:26.04
-  #           cxxstd: '26'
-  #           build-type: 'Release'
-  #           server: "redis:7.4.5-alpine"
+          - toolset: gcc-15
+            install: g++-15
+            container: ubuntu:26.04
+            cxxstd: '26'
+            build-type: 'Release'
+            server: "redis:7.4.5-alpine"
 
-  #         - toolset: clang-11
-  #           install: clang-11
-  #           container: ubuntu:22.04
-  #           cxxstd: '20'
-  #           build-type: 'Debug'
-  #           server: "redis:7.4.5-alpine"
-  #           corosio-tests: '0'
+          - toolset: clang-11
+            install: clang-11
+            container: ubuntu:22.04
+            cxxstd: '20'
+            build-type: 'Debug'
+            server: "redis:7.4.5-alpine"
+            corosio-tests: '0'
 
-  #         - toolset: clang-12
-  #           install: clang-12
-  #           container: ubuntu:22.04
-  #           cxxstd: '20'
-  #           build-type: 'Debug'
-  #           server: "redis:8.2.1-alpine"
-  #           corosio-tests: '0'
+          - toolset: clang-12
+            install: clang-12
+            container: ubuntu:22.04
+            cxxstd: '20'
+            build-type: 'Debug'
+            server: "redis:8.2.1-alpine"
+            corosio-tests: '0'
 
-  #         - toolset: clang-13
-  #           install: clang-13
-  #           container: ubuntu:22.04
-  #           cxxstd: '20'
-  #           build-type: 'Debug'
-  #           server: "valkey/valkey:8.1.3-alpine"
-  #           corosio-tests: '0'
+          - toolset: clang-13
+            install: clang-13
+            container: ubuntu:22.04
+            cxxstd: '20'
+            build-type: 'Debug'
+            server: "valkey/valkey:8.1.3-alpine"
+            corosio-tests: '0'
 
-  #         # clang-14 is the default in Ubuntu 22.04
-  #         - toolset: clang-14
-  #           install: clang-14
-  #           container: ubuntu:22.04
-  #           cxxstd: '20'
-  #           build-type: 'Debug'
-  #           server: "redis:7.4.5-alpine"
-  #           corosio-tests: '0'
+          # clang-14 is the default in Ubuntu 22.04
+          - toolset: clang-14
+            install: clang-14
+            container: ubuntu:22.04
+            cxxstd: '20'
+            build-type: 'Debug'
+            server: "redis:7.4.5-alpine"
+            corosio-tests: '0'
 
-  #         - toolset: clang-14
-  #           install: 'clang-14 libc++-14-dev libc++abi-14-dev'
-  #           container: ubuntu:22.04
-  #           cxxstd: '20'
-  #           build-type: 'Debug'
-  #           cxxflags: '-stdlib=libc++'
-  #           ldflags: '-lc++'
-  #           server: "redis:8.2.1-alpine"
-  #           corosio-tests: '0'
+          - toolset: clang-14
+            install: 'clang-14 libc++-14-dev libc++abi-14-dev'
+            container: ubuntu:22.04
+            cxxstd: '20'
+            build-type: 'Debug'
+            cxxflags: '-stdlib=libc++'
+            ldflags: '-lc++'
+            server: "redis:8.2.1-alpine"
+            corosio-tests: '0'
 
-  #         - toolset: clang-14
-  #           install: 'clang-14 libc++-14-dev libc++abi-14-dev'
-  #           container: ubuntu:22.04
-  #           cxxstd: '20'
-  #           build-type: 'Release'
-  #           cxxflags: '-stdlib=libc++'
-  #           ldflags: '-lc++'
-  #           server: "valkey/valkey:8.1.3-alpine"
+          - toolset: clang-14
+            install: 'clang-14 libc++-14-dev libc++abi-14-dev'
+            container: ubuntu:22.04
+            cxxstd: '20'
+            build-type: 'Release'
+            cxxflags: '-stdlib=libc++'
+            ldflags: '-lc++'
+            server: "valkey/valkey:8.1.3-alpine"
 
-  #         - toolset: clang-15
-  #           install: clang-15
-  #           container: ubuntu:22.04
-  #           cxxstd: '20'
-  #           build-type: 'Debug'
-  #           server: "redis:7.4.5-alpine"
-  #           corosio-tests: '0'
+          - toolset: clang-15
+            install: clang-15
+            container: ubuntu:22.04
+            cxxstd: '20'
+            build-type: 'Debug'
+            server: "redis:7.4.5-alpine"
+            corosio-tests: '0'
 
-  #         - toolset: clang-16
-  #           install: clang-16
-  #           container: ubuntu:24.04
-  #           cxxstd: '20'
-  #           build-type: 'Debug'
-  #           cxxflags: '-DBOOST_ASIO_DISABLE_LOCAL_SOCKETS=1' # If a system has no UNIX socket support, we build correctly
-  #           server: "redis:8.2.1-alpine"
-  #           corosio-tests: '0'
+          - toolset: clang-16
+            install: clang-16
+            container: ubuntu:24.04
+            cxxstd: '20'
+            build-type: 'Debug'
+            cxxflags: '-DBOOST_ASIO_DISABLE_LOCAL_SOCKETS=1' # If a system has no UNIX socket support, we build correctly
+            server: "redis:8.2.1-alpine"
+            corosio-tests: '0'
 
-  #         - toolset: clang-17
-  #           install: clang-17
-  #           container: ubuntu:24.04
-  #           cxxstd: '20'
-  #           build-type: 'Debug'
-  #           server: "valkey/valkey:8.1.3-alpine"
+          - toolset: clang-17
+            install: clang-17
+            container: ubuntu:24.04
+            cxxstd: '20'
+            build-type: 'Debug'
+            server: "valkey/valkey:8.1.3-alpine"
 
-  #         # clang-18 is the default in Ubuntu 24.04
-  #         - toolset: clang-18
-  #           install: clang-18
-  #           container: ubuntu:24.04
-  #           cxxstd: '20'
-  #           build-type: 'Debug'
-  #           server: "redis:7.4.5-alpine"
+          # clang-18 is the default in Ubuntu 24.04
+          - toolset: clang-18
+            install: clang-18
+            container: ubuntu:24.04
+            cxxstd: '20'
+            build-type: 'Debug'
+            server: "redis:7.4.5-alpine"
 
-  #         - toolset: clang-18
-  #           install: 'clang-18 libc++-18-dev libc++abi-18-dev'
-  #           container: ubuntu:24.04
-  #           cxxstd: '20'
-  #           build-type: 'Release'
-  #           cxxflags: '-stdlib=libc++'
-  #           ldflags: '-lc++'
-  #           server: "valkey/valkey:8.1.3-alpine"
+          - toolset: clang-18
+            install: 'clang-18 libc++-18-dev libc++abi-18-dev'
+            container: ubuntu:24.04
+            cxxstd: '20'
+            build-type: 'Release'
+            cxxflags: '-stdlib=libc++'
+            ldflags: '-lc++'
+            server: "valkey/valkey:8.1.3-alpine"
 
-  #         - toolset: clang-18
-  #           install: 'clang-18 libc++-18-dev libc++abi-18-dev'
-  #           container: ubuntu:24.04
-  #           cxxstd: '23'
-  #           build-type: 'Debug'
-  #           cxxflags: '-stdlib=libc++'
-  #           ldflags: '-lc++'
-  #           server: "redis:8.2.1-alpine"
+          - toolset: clang-18
+            install: 'clang-18 libc++-18-dev libc++abi-18-dev'
+            container: ubuntu:24.04
+            cxxstd: '23'
+            build-type: 'Debug'
+            cxxflags: '-stdlib=libc++'
+            ldflags: '-lc++'
+            server: "redis:8.2.1-alpine"
 
-  #         - toolset: clang-19
-  #           install: clang-19
-  #           container: ubuntu:24.04
-  #           cxxstd: '23'
-  #           build-type: 'Debug'
-  #           server: "redis:7.4.5-alpine"
+          - toolset: clang-19
+            install: clang-19
+            container: ubuntu:24.04
+            cxxstd: '23'
+            build-type: 'Debug'
+            server: "redis:7.4.5-alpine"
 
-  #         - toolset: clang-20
-  #           install: clang-20
-  #           container: ubuntu:24.04
-  #           cxxstd: '23'
-  #           build-type: 'Debug'
-  #           server: "redis:8.2.1-alpine"
+          - toolset: clang-20
+            install: clang-20
+            container: ubuntu:24.04
+            cxxstd: '23'
+            build-type: 'Debug'
+            server: "redis:8.2.1-alpine"
 
-  #         # clang-21 is the default in Ubuntu 26.04
-  #         - toolset: clang-21
-  #           install: 'clang-21 libclang-rt-21-dev'
-  #           container: ubuntu:26.04
-  #           cxxstd: '23'
-  #           build-type: 'Debug'
-  #           cxxflags: '-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all'
-  #           ldflags: '-fsanitize=address -fsanitize=undefined'
-  #           server: "valkey/valkey:8.1.3-alpine"
+          # clang-21 is the default in Ubuntu 26.04
+          - toolset: clang-21
+            install: 'clang-21 libclang-rt-21-dev'
+            container: ubuntu:26.04
+            cxxstd: '23'
+            build-type: 'Debug'
+            cxxflags: '-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all'
+            ldflags: '-fsanitize=address -fsanitize=undefined'
+            server: "valkey/valkey:8.1.3-alpine"
 
-  #         - toolset: clang-21
-  #           install: 'clang-21 libc++-21-dev libc++abi-21-dev'
-  #           container: ubuntu:26.04
-  #           cxxstd: '23'
-  #           build-type: 'Debug'
-  #           cxxflags: '-stdlib=libc++'
-  #           ldflags: '-lc++'
-  #           server: "redis:7.4.5-alpine"
+          - toolset: clang-21
+            install: 'clang-21 libc++-21-dev libc++abi-21-dev'
+            container: ubuntu:26.04
+            cxxstd: '23'
+            build-type: 'Debug'
+            cxxflags: '-stdlib=libc++'
+            ldflags: '-lc++'
+            server: "redis:7.4.5-alpine"
 
-  #         - toolset: clang-21
-  #           install: 'clang-21 libc++-21-dev libc++abi-21-dev'
-  #           container: ubuntu:26.04
-  #           cxxstd: '23'
-  #           build-type: 'Release'
-  #           cxxflags: '-stdlib=libc++'
-  #           ldflags: '-lc++'
-  #           server: "redis:8.2.1-alpine"
+          - toolset: clang-21
+            install: 'clang-21 libc++-21-dev libc++abi-21-dev'
+            container: ubuntu:26.04
+            cxxstd: '23'
+            build-type: 'Release'
+            cxxflags: '-stdlib=libc++'
+            ldflags: '-lc++'
+            server: "redis:8.2.1-alpine"
 
-  #         - toolset: clang-22
-  #           install: clang-22
-  #           container: ubuntu:26.04
-  #           cxxstd: '23'
-  #           build-type: 'Debug'
-  #           server: "valkey/valkey:8.1.3-alpine"
+          - toolset: clang-22
+            install: clang-22
+            container: ubuntu:26.04
+            cxxstd: '23'
+            build-type: 'Debug'
+            server: "valkey/valkey:8.1.3-alpine"
 
-  #   runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
     
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v6
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
     
-  #   - name: Generate TLS certificates
-  #     run: |
-  #       ./tools/gen-certificates.sh
+    - name: Generate TLS certificates
+      run: |
+        ./tools/gen-certificates.sh
     
-  #   - name: Set up the required containers
-  #     run: |
-  #       BUILDER_IMAGE=${{ matrix.container }} SERVER_IMAGE=${{ matrix.server }} docker compose -f tools/docker-compose.yml up -d --wait || (docker compose logs; exit 1)
+    - name: Set up the required containers
+      run: |
+        BUILDER_IMAGE=${{ matrix.container }} SERVER_IMAGE=${{ matrix.server }} docker compose -f tools/docker-compose.yml up -d --wait || (docker compose logs; exit 1)
       
-  #   - name: Install dependencies
-  #     run: |
-  #       docker exec builder apt-get update
-  #       docker exec --env DEBIAN_FRONTEND=noninteractive builder apt-get -y --no-install-recommends install \
-  #         git \
-  #         g++ \
-  #         libssl-dev \
-  #         make \
-  #         ca-certificates \
-  #         cmake \
-  #         protobuf-compiler \
-  #         python3 \
-  #         ${{ matrix.install }}
+    - name: Install dependencies
+      run: |
+        docker exec builder apt-get update
+        docker exec --env DEBIAN_FRONTEND=noninteractive builder apt-get -y --no-install-recommends install \
+          git \
+          g++ \
+          libssl-dev \
+          make \
+          ca-certificates \
+          cmake \
+          protobuf-compiler \
+          python3 \
+          ${{ matrix.install }}
 
-  #   - name: Setup Boost
-  #     run: docker exec builder /boost-redis/tools/ci.py setup-boost --source-dir=/boost-redis
+    - name: Setup Boost
+      run: docker exec builder /boost-redis/tools/ci.py setup-boost --source-dir=/boost-redis
 
-  #   - name: Build a Boost distribution using B2
-  #     run: |
-  #       docker exec builder /boost-redis/tools/ci.py build-b2-distro \
-  #         --toolset ${{ matrix.toolset }}
+    - name: Build a Boost distribution using B2
+      run: |
+        docker exec builder /boost-redis/tools/ci.py build-b2-distro \
+          --toolset ${{ matrix.toolset }}
 
-  #   # The CMake superproject build also drives the project tests, including
-  #   # integration tests against the Redis server set up above.
-  #   - name: Build a Boost distribution and run the tests using CMake
-  #     run: |
-  #       docker exec builder /boost-redis/tools/ci.py build-cmake-distro \
-  #         --build-type ${{ matrix.build-type }} \
-  #         --cxxstd ${{ matrix.cxxstd }} \
-  #         --toolset ${{ matrix.toolset }} \
-  #         "--cxxflags=${{ matrix.cxxflags }} -Werror" \
-  #         "--ldflags=${{ matrix.ldflags }}"
+    # The CMake superproject build also drives the project tests, including
+    # integration tests against the Redis server set up above.
+    - name: Build a Boost distribution and run the tests using CMake
+      run: |
+        docker exec builder /boost-redis/tools/ci.py build-cmake-distro \
+          --build-type ${{ matrix.build-type }} \
+          --cxxstd ${{ matrix.cxxstd }} \
+          --toolset ${{ matrix.toolset }} \
+          "--cxxflags=${{ matrix.cxxflags }} -Werror" \
+          "--ldflags=${{ matrix.ldflags }}"
 
-  #   - name: Run add_subdirectory tests
-  #     run: |
-  #       docker exec builder /boost-redis/tools/ci.py run-cmake-add-subdirectory-tests \
-  #         --build-type ${{ matrix.build-type }} \
-  #         --cxxstd ${{ matrix.cxxstd }} \
-  #         --toolset ${{ matrix.toolset }} \
-  #         "--cxxflags=${{ matrix.cxxflags }} -Werror" \
-  #         "--ldflags=${{ matrix.ldflags }}"
+    - name: Run add_subdirectory tests
+      run: |
+        docker exec builder /boost-redis/tools/ci.py run-cmake-add-subdirectory-tests \
+          --build-type ${{ matrix.build-type }} \
+          --cxxstd ${{ matrix.cxxstd }} \
+          --toolset ${{ matrix.toolset }} \
+          "--cxxflags=${{ matrix.cxxflags }} -Werror" \
+          "--ldflags=${{ matrix.ldflags }}"
 
-  #   - name: Run find_package tests with the built cmake distribution
-  #     run: |
-  #       docker exec builder /boost-redis/tools/ci.py run-cmake-find-package-tests \
-  #         --build-type ${{ matrix.build-type }} \
-  #         --cxxstd ${{ matrix.cxxstd }} \
-  #         --toolset ${{ matrix.toolset }} \
-  #         "--cxxflags=${{ matrix.cxxflags }} -Werror" \
-  #         "--ldflags=${{ matrix.ldflags }}"
+    - name: Run find_package tests with the built cmake distribution
+      run: |
+        docker exec builder /boost-redis/tools/ci.py run-cmake-find-package-tests \
+          --build-type ${{ matrix.build-type }} \
+          --cxxstd ${{ matrix.cxxstd }} \
+          --toolset ${{ matrix.toolset }} \
+          "--cxxflags=${{ matrix.cxxflags }} -Werror" \
+          "--ldflags=${{ matrix.ldflags }}"
 
-  #   - name: Run find_package tests with the built b2 distribution
-  #     run: |
-  #       docker exec builder /boost-redis/tools/ci.py run-cmake-b2-find-package-tests \
-  #         --build-type ${{ matrix.build-type }} \
-  #         --cxxstd ${{ matrix.cxxstd }} \
-  #         --toolset ${{ matrix.toolset }} \
-  #         "--cxxflags=${{ matrix.cxxflags }} -Werror" \
-  #         "--ldflags=${{ matrix.ldflags }}"
+    - name: Run find_package tests with the built b2 distribution
+      run: |
+        docker exec builder /boost-redis/tools/ci.py run-cmake-b2-find-package-tests \
+          --build-type ${{ matrix.build-type }} \
+          --cxxstd ${{ matrix.cxxstd }} \
+          --toolset ${{ matrix.toolset }} \
+          "--cxxflags=${{ matrix.cxxflags }} -Werror" \
+          "--ldflags=${{ matrix.ldflags }}"
 
-  # posix-b2:
-  #   name: "B2 ${{ matrix.toolset }}"
-  #   defaults:
-  #     run:
-  #       shell: bash
+  posix-b2:
+    name: "B2 ${{ matrix.toolset }}"
+    defaults:
+      run:
+        shell: bash
 
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         # We don't have integration tests here, so we only test the compilers
-  #         # that get installed by default in Ubuntu 22.04, 24.04 and 26.04
-  #         - toolset: gcc-11
-  #           install: g++-11
-  #           cxxstd: "11,17,20" # Having C++11 shouldn't break the build
-  #           container: ubuntu:22.04
-  #         - toolset: gcc-13
-  #           install: g++-13
-  #           cxxstd: "17,20,23"
-  #           container: ubuntu:24.04
-  #         - toolset: gcc-15
-  #           install: g++-15
-  #           cxxstd: "17,20,23"
-  #           container: ubuntu:26.04
-  #         - toolset: clang-18
-  #           install: clang-18
-  #           cxxstd: "11,17,20"
-  #           container: ubuntu:24.04
-  #         - toolset: clang-21
-  #           install: clang-21
-  #           cxxstd: "17,20,23"
-  #           container: ubuntu:26.04
-  #   runs-on: ubuntu-latest
-  #   container: ${{matrix.container}}
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v6
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # We don't have integration tests here, so we only test the compilers
+          # that get installed by default in Ubuntu 22.04, 24.04 and 26.04
+          - toolset: gcc-11
+            install: g++-11
+            cxxstd: "11,17,20" # Having C++11 shouldn't break the build
+            container: ubuntu:22.04
+          - toolset: gcc-13
+            install: g++-13
+            cxxstd: "17,20,23"
+            container: ubuntu:24.04
+          - toolset: gcc-15
+            install: g++-15
+            cxxstd: "17,20,23"
+            container: ubuntu:26.04
+          - toolset: clang-18
+            install: clang-18
+            cxxstd: "11,17,20"
+            container: ubuntu:24.04
+          - toolset: clang-21
+            install: clang-21
+            cxxstd: "17,20,23"
+            container: ubuntu:26.04
+    runs-on: ubuntu-latest
+    container: ${{matrix.container}}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
 
-  #   - name: Setup container environment
-  #     if: matrix.container
-  #     run: |
-  #       export DEBIAN_FRONTEND=noninteractive
-  #       apt-get update
-  #       apt-get -y install python3 git g++ libssl-dev ${{ matrix.install }}
+    - name: Setup container environment
+      if: matrix.container
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get -y install python3 git g++ libssl-dev ${{ matrix.install }}
 
-  #   - name: Setup Boost
-  #     run: ./tools/ci.py setup-boost --source-dir=$(pwd)
+    - name: Setup Boost
+      run: ./tools/ci.py setup-boost --source-dir=$(pwd)
     
-  #   - name: Build and run project tests using B2
-  #     run: |
-  #       python3 tools/ci.py run-b2-tests \
-  #         --toolset ${{ matrix.toolset }} \
-  #         --cxxstd ${{ matrix.cxxstd }} \
-  #         --variant debug,release
+    - name: Build and run project tests using B2
+      run: |
+        python3 tools/ci.py run-b2-tests \
+          --toolset ${{ matrix.toolset }} \
+          --cxxstd ${{ matrix.cxxstd }} \
+          --variant debug,release
 
-  # # Checks that we don't have any errors in docs
-  # check-docs:
-  #   name: Check docs
-  #   defaults:
-  #     run:
-  #       shell: bash
+  # Checks that we don't have any errors in docs
+  check-docs:
+    name: Check docs
+    defaults:
+      run:
+        shell: bash
 
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v6
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
 
-  #   - name: Setup Boost
-  #     run: ./tools/ci.py setup-boost --source-dir=$(pwd)
+    - name: Setup Boost
+      run: ./tools/ci.py setup-boost --source-dir=$(pwd)
     
-  #   - name: Build docs
-  #     run: |
-  #       cd ~/boost-root
-  #       ./b2 libs/redis/doc
-  #       [ -f ~/boost-root/libs/redis/doc/html/index.html ]
+    - name: Build docs
+      run: |
+        cd ~/boost-root
+        ./b2 libs/redis/doc
+        [ -f ~/boost-root/libs/redis/doc/html/index.html ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,72 +11,72 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  windows-cmake:
-    name: "CMake ${{matrix.toolset}} ${{matrix.build-type}} C++${{matrix.cxxstd}}"
-    runs-on: ${{matrix.os}}
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          #- { toolset: msvc-14.2, os: windows-2019, generator: "Visual Studio 16 2019", cxxstd: '17', build-type: 'Debug',   build-shared-libs: 1 }
-          #- { toolset: msvc-14.2, os: windows-2019, generator: "Visual Studio 16 2019", cxxstd: '17', build-type: 'Release', build-shared-libs: 0 }
-          - { toolset: msvc-14.3, os: windows-2022, generator: "Visual Studio 17 2022", cxxstd: '20', build-type: 'Debug',   build-shared-libs: 0 }
-          - { toolset: msvc-14.3, os: windows-2022, generator: "Visual Studio 17 2022", cxxstd: '20', build-type: 'Release', build-shared-libs: 1 }
-    env:
-      CMAKE_BUILD_PARALLEL_LEVEL: 4
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+  # windows-cmake:
+  #   name: "CMake ${{matrix.toolset}} ${{matrix.build-type}} C++${{matrix.cxxstd}}"
+  #   runs-on: ${{matrix.os}}
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         #- { toolset: msvc-14.2, os: windows-2019, generator: "Visual Studio 16 2019", cxxstd: '17', build-type: 'Debug',   build-shared-libs: 1 }
+  #         #- { toolset: msvc-14.2, os: windows-2019, generator: "Visual Studio 16 2019", cxxstd: '17', build-type: 'Release', build-shared-libs: 0 }
+  #         - { toolset: msvc-14.3, os: windows-2022, generator: "Visual Studio 17 2022", cxxstd: '20', build-type: 'Debug',   build-shared-libs: 0 }
+  #         - { toolset: msvc-14.3, os: windows-2022, generator: "Visual Studio 17 2022", cxxstd: '20', build-type: 'Release', build-shared-libs: 1 }
+  #   env:
+  #     CMAKE_BUILD_PARALLEL_LEVEL: 4
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
 
-    - name: Setup Boost
-      run: python3 tools/ci.py setup-boost --source-dir=$(pwd)
+  #   - name: Setup Boost
+  #     run: python3 tools/ci.py setup-boost --source-dir=$(pwd)
 
-    - name: Build a Boost distribution using B2
-      run: |
-        python3 tools/ci.py build-b2-distro \
-          --toolset ${{ matrix.toolset }}
+  #   - name: Build a Boost distribution using B2
+  #     run: |
+  #       python3 tools/ci.py build-b2-distro \
+  #         --toolset ${{ matrix.toolset }}
 
-    # No Redis server is available on this job, so integration tests are skipped.
-    # Unit tests are built and run via the CMake superproject build.
-    - name: Build a Boost distribution and run the tests using CMake
-      run: |
-        python3 tools/ci.py build-cmake-distro \
-          --build-type ${{ matrix.build-type }} \
-          --cxxstd ${{ matrix.cxxstd }} \
-          --toolset ${{ matrix.toolset }} \
-          --generator "${{ matrix.generator }}" \
-          --build-shared-libs ${{ matrix.build-shared-libs }} \
-          --integration-tests 0
+  #   # No Redis server is available on this job, so integration tests are skipped.
+  #   # Unit tests are built and run via the CMake superproject build.
+  #   - name: Build a Boost distribution and run the tests using CMake
+  #     run: |
+  #       python3 tools/ci.py build-cmake-distro \
+  #         --build-type ${{ matrix.build-type }} \
+  #         --cxxstd ${{ matrix.cxxstd }} \
+  #         --toolset ${{ matrix.toolset }} \
+  #         --generator "${{ matrix.generator }}" \
+  #         --build-shared-libs ${{ matrix.build-shared-libs }} \
+  #         --integration-tests 0
 
-    - name: Run add_subdirectory tests
-      run: |
-        python3 tools/ci.py run-cmake-add-subdirectory-tests \
-          --build-type ${{ matrix.build-type }} \
-          --cxxstd ${{ matrix.cxxstd }} \
-          --toolset ${{ matrix.toolset }} \
-          --generator "${{ matrix.generator }}" \
-          --build-shared-libs ${{ matrix.build-shared-libs }}
+  #   - name: Run add_subdirectory tests
+  #     run: |
+  #       python3 tools/ci.py run-cmake-add-subdirectory-tests \
+  #         --build-type ${{ matrix.build-type }} \
+  #         --cxxstd ${{ matrix.cxxstd }} \
+  #         --toolset ${{ matrix.toolset }} \
+  #         --generator "${{ matrix.generator }}" \
+  #         --build-shared-libs ${{ matrix.build-shared-libs }}
 
-    - name: Run find_package tests with the built cmake distribution
-      run: |
-        python3 tools/ci.py run-cmake-find-package-tests \
-          --build-type ${{ matrix.build-type }} \
-          --cxxstd ${{ matrix.cxxstd }} \
-          --toolset ${{ matrix.toolset }} \
-          --generator "${{ matrix.generator }}" \
-          --build-shared-libs ${{ matrix.build-shared-libs }}
+  #   - name: Run find_package tests with the built cmake distribution
+  #     run: |
+  #       python3 tools/ci.py run-cmake-find-package-tests \
+  #         --build-type ${{ matrix.build-type }} \
+  #         --cxxstd ${{ matrix.cxxstd }} \
+  #         --toolset ${{ matrix.toolset }} \
+  #         --generator "${{ matrix.generator }}" \
+  #         --build-shared-libs ${{ matrix.build-shared-libs }}
 
-    - name: Run find_package tests with the built b2 distribution
-      run: |
-        python3 tools/ci.py run-cmake-b2-find-package-tests \
-          --build-type ${{ matrix.build-type }} \
-          --cxxstd ${{ matrix.cxxstd }} \
-          --toolset ${{ matrix.toolset }} \
-          --generator "${{ matrix.generator }}" \
-          --build-shared-libs ${{ matrix.build-shared-libs }}
+  #   - name: Run find_package tests with the built b2 distribution
+  #     run: |
+  #       python3 tools/ci.py run-cmake-b2-find-package-tests \
+  #         --build-type ${{ matrix.build-type }} \
+  #         --cxxstd ${{ matrix.cxxstd }} \
+  #         --toolset ${{ matrix.toolset }} \
+  #         --generator "${{ matrix.generator }}" \
+  #         --build-shared-libs ${{ matrix.build-shared-libs }}
 
   windows-b2:
     name: "B2 ${{matrix.toolset}}"
@@ -109,242 +109,242 @@ jobs:
           --cxxstd 17,20 \
           --variant debug,release
 
-  posix-cmake:
-    name: "CMake ${{ matrix.toolset }} ${{ matrix.cxxstd }} ${{ matrix.build-type }} ${{ matrix.cxxflags }}"
-    defaults:
-      run:
-        shell: bash
+  # posix-cmake:
+  #   name: "CMake ${{ matrix.toolset }} ${{ matrix.cxxstd }} ${{ matrix.build-type }} ${{ matrix.cxxflags }}"
+  #   defaults:
+  #     run:
+  #       shell: bash
 
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - toolset: gcc-11
-            install: g++-11
-            container: ubuntu:22.04
-            cxxstd: '17'
-            build-type: 'Debug'
-            ldflags: ''
-            server: "redis:7.4.5-alpine"
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - toolset: gcc-11
+  #           install: g++-11
+  #           container: ubuntu:22.04
+  #           cxxstd: '17'
+  #           build-type: 'Debug'
+  #           ldflags: ''
+  #           server: "redis:7.4.5-alpine"
 
-          - toolset: gcc-11
-            install: g++-11
-            container: ubuntu:22.04
-            cxxstd: '20'
-            build-type: 'Release'
-            ldflags: ''
-            server: "redis:7.4.5-alpine"
+  #         - toolset: gcc-11
+  #           install: g++-11
+  #           container: ubuntu:22.04
+  #           cxxstd: '20'
+  #           build-type: 'Release'
+  #           ldflags: ''
+  #           server: "redis:7.4.5-alpine"
 
-          - toolset: clang-11
-            install: clang-11
-            container: ubuntu:22.04
-            cxxstd: '17'
-            build-type: 'Debug'
-            ldflags: ''
-            server: "redis:7.4.5-alpine"
+  #         - toolset: clang-11
+  #           install: clang-11
+  #           container: ubuntu:22.04
+  #           cxxstd: '17'
+  #           build-type: 'Debug'
+  #           ldflags: ''
+  #           server: "redis:7.4.5-alpine"
 
-          - toolset: clang-11
-            install: clang-11
-            container: ubuntu:22.04
-            cxxstd: '20'
-            build-type: 'Debug'
-            ldflags: ''
-            server: "redis:7.4.5-alpine"
+  #         - toolset: clang-11
+  #           install: clang-11
+  #           container: ubuntu:22.04
+  #           cxxstd: '20'
+  #           build-type: 'Debug'
+  #           ldflags: ''
+  #           server: "redis:7.4.5-alpine"
 
-          - toolset: clang-13
-            install: clang-13
-            container: ubuntu:22.04
-            cxxstd: '17'
-            build-type: 'Release'
-            ldflags: ''
-            server: "redis:8.2.1-alpine"
+  #         - toolset: clang-13
+  #           install: clang-13
+  #           container: ubuntu:22.04
+  #           cxxstd: '17'
+  #           build-type: 'Release'
+  #           ldflags: ''
+  #           server: "redis:8.2.1-alpine"
 
-          - toolset: clang-13
-            install: clang-13
-            container: ubuntu:22.04
-            cxxstd: '20'
-            build-type: 'Release'
-            ldflags: ''
-            server: "redis:8.2.1-alpine"
+  #         - toolset: clang-13
+  #           install: clang-13
+  #           container: ubuntu:22.04
+  #           cxxstd: '20'
+  #           build-type: 'Release'
+  #           ldflags: ''
+  #           server: "redis:8.2.1-alpine"
 
-          - toolset: clang-14
-            install: 'clang-14 libc++-14-dev libc++abi-14-dev'
-            container: ubuntu:22.04
-            cxxstd: '17'
-            build-type: 'Debug'
-            cxxflags: '-stdlib=libc++'
-            ldflags: '-lc++'
-            server: "redis:8.2.1-alpine"
+  #         - toolset: clang-14
+  #           install: 'clang-14 libc++-14-dev libc++abi-14-dev'
+  #           container: ubuntu:22.04
+  #           cxxstd: '17'
+  #           build-type: 'Debug'
+  #           cxxflags: '-stdlib=libc++'
+  #           ldflags: '-lc++'
+  #           server: "redis:8.2.1-alpine"
 
-          - toolset: clang-14
-            install: 'clang-14 libc++-14-dev libc++abi-14-dev'
-            container: ubuntu:22.04
-            cxxstd: '20'
-            build-type: 'Release'
-            cxxflags: '-stdlib=libc++'
-            ldflags: '-lc++'
-            server: "redis:8.2.1-alpine"
+  #         - toolset: clang-14
+  #           install: 'clang-14 libc++-14-dev libc++abi-14-dev'
+  #           container: ubuntu:22.04
+  #           cxxstd: '20'
+  #           build-type: 'Release'
+  #           cxxflags: '-stdlib=libc++'
+  #           ldflags: '-lc++'
+  #           server: "redis:8.2.1-alpine"
           
-          - toolset: clang-19
-            install: 'clang-19'
-            container: ubuntu:24.04
-            cxxstd: '23'
-            build-type: 'Debug'
-            cxxflags: '-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all'
-            ldflags: '-fsanitize=address -fsanitize=undefined'
-            server: "redis:8.2.1-alpine"
+  #         - toolset: clang-19
+  #           install: 'clang-19'
+  #           container: ubuntu:24.04
+  #           cxxstd: '23'
+  #           build-type: 'Debug'
+  #           cxxflags: '-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all'
+  #           ldflags: '-fsanitize=address -fsanitize=undefined'
+  #           server: "redis:8.2.1-alpine"
 
-          - toolset: gcc-14
-            install: 'g++-14'
-            container: ubuntu:24.04
-            cxxstd: '23'
-            build-type: 'Debug'
-            cxxflags: '-DBOOST_ASIO_DISABLE_LOCAL_SOCKETS=1' # If a system had no UNIX socket support, we build correctly
-            server: "valkey/valkey:8.1.3-alpine"
+  #         - toolset: gcc-14
+  #           install: 'g++-14'
+  #           container: ubuntu:24.04
+  #           cxxstd: '23'
+  #           build-type: 'Debug'
+  #           cxxflags: '-DBOOST_ASIO_DISABLE_LOCAL_SOCKETS=1' # If a system had no UNIX socket support, we build correctly
+  #           server: "valkey/valkey:8.1.3-alpine"
           
-          - toolset: gcc-14
-            install: 'g++-14'
-            container: ubuntu:24.04
-            cxxstd: '23'
-            build-type: 'Debug'
-            cxxflags: '-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all'
-            ldflags: '-fsanitize=address -fsanitize=undefined'
-            server: "valkey/valkey:8.1.3-alpine"
+  #         - toolset: gcc-14
+  #           install: 'g++-14'
+  #           container: ubuntu:24.04
+  #           cxxstd: '23'
+  #           build-type: 'Debug'
+  #           cxxflags: '-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all'
+  #           ldflags: '-fsanitize=address -fsanitize=undefined'
+  #           server: "valkey/valkey:8.1.3-alpine"
 
-    runs-on: ubuntu-latest
-    env:
-      CXXFLAGS: ${{matrix.cxxflags}} -Wall -Wextra
-      LDFLAGS:  ${{matrix.ldflags}}
-      CMAKE_BUILD_PARALLEL_LEVEL: 4
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     CXXFLAGS: ${{matrix.cxxflags}} -Wall -Wextra
+  #     LDFLAGS:  ${{matrix.ldflags}}
+  #     CMAKE_BUILD_PARALLEL_LEVEL: 4
     
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
     
-    - name: Generate TLS certificates
-      run: |
-        ./tools/gen-certificates.sh
+  #   - name: Generate TLS certificates
+  #     run: |
+  #       ./tools/gen-certificates.sh
     
-    - name: Set up the required containers
-      run: |
-        BUILDER_IMAGE=${{ matrix.container }} SERVER_IMAGE=${{ matrix.server }} docker compose -f tools/docker-compose.yml up -d --wait || (docker compose logs; exit 1)
+  #   - name: Set up the required containers
+  #     run: |
+  #       BUILDER_IMAGE=${{ matrix.container }} SERVER_IMAGE=${{ matrix.server }} docker compose -f tools/docker-compose.yml up -d --wait || (docker compose logs; exit 1)
       
-    - name: Install dependencies
-      run: |
-        docker exec builder apt-get update
-        docker exec builder apt-get -y --no-install-recommends install \
-          git \
-          g++ \
-          libssl-dev \
-          make \
-          ca-certificates \
-          cmake \
-          protobuf-compiler \
-          python3 \
-          ${{ matrix.install }}
+  #   - name: Install dependencies
+  #     run: |
+  #       docker exec builder apt-get update
+  #       docker exec builder apt-get -y --no-install-recommends install \
+  #         git \
+  #         g++ \
+  #         libssl-dev \
+  #         make \
+  #         ca-certificates \
+  #         cmake \
+  #         protobuf-compiler \
+  #         python3 \
+  #         ${{ matrix.install }}
 
-    - name: Setup Boost
-      run: docker exec builder /boost-redis/tools/ci.py setup-boost --source-dir=/boost-redis
+  #   - name: Setup Boost
+  #     run: docker exec builder /boost-redis/tools/ci.py setup-boost --source-dir=/boost-redis
 
-    - name: Build a Boost distribution using B2
-      run: |
-        docker exec builder /boost-redis/tools/ci.py build-b2-distro \
-          --toolset ${{ matrix.toolset }}
+  #   - name: Build a Boost distribution using B2
+  #     run: |
+  #       docker exec builder /boost-redis/tools/ci.py build-b2-distro \
+  #         --toolset ${{ matrix.toolset }}
 
-    # The CMake superproject build also drives the project tests, including
-    # integration tests against the Redis server set up above.
-    - name: Build a Boost distribution and run the tests using CMake
-      run: |
-        docker exec builder /boost-redis/tools/ci.py build-cmake-distro \
-          --build-type ${{ matrix.build-type }} \
-          --cxxstd ${{ matrix.cxxstd }} \
-          --toolset ${{ matrix.toolset }}
+  #   # The CMake superproject build also drives the project tests, including
+  #   # integration tests against the Redis server set up above.
+  #   - name: Build a Boost distribution and run the tests using CMake
+  #     run: |
+  #       docker exec builder /boost-redis/tools/ci.py build-cmake-distro \
+  #         --build-type ${{ matrix.build-type }} \
+  #         --cxxstd ${{ matrix.cxxstd }} \
+  #         --toolset ${{ matrix.toolset }}
 
-    - name: Run add_subdirectory tests
-      run: |
-        docker exec builder /boost-redis/tools/ci.py run-cmake-add-subdirectory-tests \
-          --build-type ${{ matrix.build-type }} \
-          --cxxstd ${{ matrix.cxxstd }} \
-          --toolset ${{ matrix.toolset }}
+  #   - name: Run add_subdirectory tests
+  #     run: |
+  #       docker exec builder /boost-redis/tools/ci.py run-cmake-add-subdirectory-tests \
+  #         --build-type ${{ matrix.build-type }} \
+  #         --cxxstd ${{ matrix.cxxstd }} \
+  #         --toolset ${{ matrix.toolset }}
 
-    - name: Run find_package tests with the built cmake distribution
-      run: |
-        docker exec builder /boost-redis/tools/ci.py run-cmake-find-package-tests \
-          --build-type ${{ matrix.build-type }} \
-          --cxxstd ${{ matrix.cxxstd }} \
-          --toolset ${{ matrix.toolset }}
+  #   - name: Run find_package tests with the built cmake distribution
+  #     run: |
+  #       docker exec builder /boost-redis/tools/ci.py run-cmake-find-package-tests \
+  #         --build-type ${{ matrix.build-type }} \
+  #         --cxxstd ${{ matrix.cxxstd }} \
+  #         --toolset ${{ matrix.toolset }}
 
-    - name: Run find_package tests with the built b2 distribution
-      run: |
-        docker exec builder /boost-redis/tools/ci.py run-cmake-b2-find-package-tests \
-          --build-type ${{ matrix.build-type }} \
-          --cxxstd ${{ matrix.cxxstd }} \
-          --toolset ${{ matrix.toolset }}
+  #   - name: Run find_package tests with the built b2 distribution
+  #     run: |
+  #       docker exec builder /boost-redis/tools/ci.py run-cmake-b2-find-package-tests \
+  #         --build-type ${{ matrix.build-type }} \
+  #         --cxxstd ${{ matrix.cxxstd }} \
+  #         --toolset ${{ matrix.toolset }}
 
-  posix-b2:
-    name: "B2 ${{ matrix.toolset }}"
-    defaults:
-      run:
-        shell: bash
+  # posix-b2:
+  #   name: "B2 ${{ matrix.toolset }}"
+  #   defaults:
+  #     run:
+  #       shell: bash
 
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - toolset: gcc-11
-            install: g++-11
-            cxxstd: "11,17,20" # Having C++11 shouldn't break the build
-            os: ubuntu-latest
-            container: ubuntu:22.04
-          - toolset: clang-14
-            install: clang-14
-            os: ubuntu-latest
-            container: ubuntu:22.04
-            cxxstd: "17,20"
-    runs-on: ${{ matrix.os }}
-    container: ${{matrix.container}}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - toolset: gcc-11
+  #           install: g++-11
+  #           cxxstd: "11,17,20" # Having C++11 shouldn't break the build
+  #           os: ubuntu-latest
+  #           container: ubuntu:22.04
+  #         - toolset: clang-14
+  #           install: clang-14
+  #           os: ubuntu-latest
+  #           container: ubuntu:22.04
+  #           cxxstd: "17,20"
+  #   runs-on: ${{ matrix.os }}
+  #   container: ${{matrix.container}}
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
 
-    - name: Setup container environment
-      if: matrix.container
-      run: |
-        apt-get update
-        apt-get -y install sudo python3 git g++ libssl-dev
+  #   - name: Setup container environment
+  #     if: matrix.container
+  #     run: |
+  #       apt-get update
+  #       apt-get -y install sudo python3 git g++ libssl-dev
 
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get -y install python3 ${{ matrix.install }}
+  #   - name: Install dependencies
+  #     run: |
+  #       sudo apt-get update
+  #       sudo apt-get -y install python3 ${{ matrix.install }}
 
-    - name: Setup Boost
-      run: ./tools/ci.py setup-boost --source-dir=$(pwd)
+  #   - name: Setup Boost
+  #     run: ./tools/ci.py setup-boost --source-dir=$(pwd)
     
-    - name: Build and run project tests using B2
-      run: |
-        python3 tools/ci.py run-b2-tests \
-          --toolset ${{ matrix.toolset }} \
-          --cxxstd ${{ matrix.cxxstd }} \
-          --variant debug,release
+  #   - name: Build and run project tests using B2
+  #     run: |
+  #       python3 tools/ci.py run-b2-tests \
+  #         --toolset ${{ matrix.toolset }} \
+  #         --cxxstd ${{ matrix.cxxstd }} \
+  #         --variant debug,release
 
-  # Checks that we don't have any errors in docs
-  check-docs:
-    name: Check docs
-    defaults:
-      run:
-        shell: bash
+  # # Checks that we don't have any errors in docs
+  # check-docs:
+  #   name: Check docs
+  #   defaults:
+  #     run:
+  #       shell: bash
 
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
 
-    - name: Setup Boost
-      run: ./tools/ci.py setup-boost --source-dir=$(pwd)
+  #   - name: Setup Boost
+  #     run: ./tools/ci.py setup-boost --source-dir=$(pwd)
     
-    - name: Build docs
-      run: |
-        cd ~/boost-root
-        ./b2 libs/redis/doc
-        [ -f ~/boost-root/libs/redis/doc/html/index.html ]
+  #   - name: Build docs
+  #     run: |
+  #       cd ~/boost-root
+  #       ./b2 libs/redis/doc
+  #       [ -f ~/boost-root/libs/redis/doc/html/index.html ]

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -2,9 +2,26 @@
 import-search /boost/config/checks ;
 import config : requires ;
 import ac ;
+import indirect ;
 
 # Configure openssl if it hasn't been done yet
 using openssl ;
+
+# Provide a way to fail the build if OpenSSL is not found - used by CIs
+rule do_fail_impl ( a * )
+{
+    exit "OpenSSL could not be found. Don't build target fail_if_no_openssl to skip this check" ;
+}
+
+local do_fail = [ indirect.make do_fail_impl ] ;
+
+alias fail_if_no_openssl
+    : requirements
+        [ ac.check-library /openssl//ssl    : : <conditional>@$(do_fail) ]
+        [ ac.check-library /openssl//crypto : : <conditional>@$(do_fail) ]
+;
+
+explicit fail_if_no_openssl ;
 
 # Use these requirements as both regular and usage requirements across all tests
 local requirements =
@@ -85,3 +102,4 @@ for local test in $(tests)
     : target-name $(test)
     ;
 }
+

--- a/test/test_serialization.cpp
+++ b/test/test_serialization.cpp
@@ -142,7 +142,7 @@ void test_pair_custom()
 void test_tuple()
 {
    std::vector<std::tuple<std::string_view, int, unsigned char>> vec{
-      {"k1", 42, 1}
+      {"k1", 42, static_cast<unsigned char>(1)}
    };
    request req;
    req.push_range("GET", vec);

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -258,19 +258,26 @@ def _run_b2_tests(
     toolset: str
 ):
     os.chdir(str(_boost_root))
-    _run([
-        _b2_command,
-        '--abbreviate-paths',
-        'toolset={}'.format(toolset),
-        'cxxstd={}'.format(cxxstd),
-        'variant={}'.format(variant),
-        'warnings=extra',
-        'warnings-as-errors=on',
-        '-d+4',
-        '-j4',
-        'libs/redis/test',
-        'libs/redis/test//fail_if_no_openssl'
-    ])
+    try:
+        _run([
+            _b2_command,
+            '--abbreviate-paths',
+            'toolset={}'.format(toolset),
+            'cxxstd={}'.format(cxxstd),
+            'variant={}'.format(variant),
+            'warnings=extra',
+            'warnings-as-errors=on',
+            '-d+4',
+            '-j4',
+            'libs/redis/test',
+            'libs/redis/test//fail_if_no_openssl'
+        ])
+    except:
+        with open(_boost_root.joinpath('bin.v2', 'config.log'), 'rt') as f:
+            contents = f.read()
+        print('Config log')
+        print(contents, flush=True)
+        raise
 
 
 def main():

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -267,7 +267,8 @@ def _run_b2_tests(
         'warnings=extra',
         'warnings-as-errors=on',
         '-j4',
-        'libs/redis/test'
+        'libs/redis/test',
+        'libs/redis/test//fail_if_no_openssl'
     ])
 
 

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -266,6 +266,7 @@ def _run_b2_tests(
         'variant={}'.format(variant),
         'warnings=extra',
         'warnings-as-errors=on',
+        '-d+4',
         '-j4',
         'libs/redis/test',
         'libs/redis/test//fail_if_no_openssl'

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -286,26 +286,18 @@ def _run_b2_tests(
     toolset: str
 ):
     os.chdir(str(_boost_root))
-    try:
-        _run([
-            _b2_command,
-            '--abbreviate-paths',
-            'toolset={}'.format(toolset),
-            'cxxstd={}'.format(cxxstd),
-            'variant={}'.format(variant),
-            'warnings=extra',
-            'warnings-as-errors=on',
-            '-d+4',
-            '-j4',
-            'libs/redis/test',
-            'libs/redis/test//fail_if_no_openssl'
-        ])
-    except:
-        with open(_boost_root.joinpath('bin.v2', 'config.log'), 'rt') as f:
-            contents = f.read()
-        print('Config log')
-        print(contents, flush=True)
-        raise
+    _run([
+        _b2_command,
+        '--abbreviate-paths',
+        'toolset={}'.format(toolset),
+        'cxxstd={}'.format(cxxstd),
+        'variant={}'.format(variant),
+        'warnings=extra',
+        'warnings-as-errors=on',
+        '-j4',
+        'libs/redis/test',
+        'libs/redis/test//fail_if_no_openssl'
+    ])
 
 
 def main():

--- a/tools/user-config.jam
+++ b/tools/user-config.jam
@@ -3,8 +3,10 @@
 # Layout matches the Shining Light Productions OpenSSL installer that ships in
 # the actions/runner-images Windows 2022 image:
 #   <root>/include/                  headers
-#   <root>/lib/VC/x64/MD/*.lib       release libs (linked against /MD runtime)
-#   <root>/lib/VC/x64/MDd/*.lib      debug libs (linked against /MDd runtime)
+#   <root>/lib/VC/x64/MD/*.lib       release libs (linked against /MD  runtime)
+#   <root>/lib/VC/x64/MDd/*.lib      debug   libs (linked against /MDd runtime)
+#   <root>/lib/VC/x64/MT/*.lib       release libs (linked against /MT  runtime)
+#   <root>/lib/VC/x64/MTd/*.lib      debug   libs (linked against /MTd runtime)
 #
 # Conditional <search> paths route b2 to the right .lib for the variant being built.
 
@@ -12,8 +14,10 @@ local openssl_root = "C:/Program Files/OpenSSL" ;
 
 using openssl : :
     <include>$(openssl_root)/include
-    <variant>release:<search>$(openssl_root)/lib/VC/x64/MD
-    <variant>debug:<search>$(openssl_root)/lib/VC/x64/MDd
+    <runtime-link>shared,<variant>release:<search>$(openssl_root)/lib/VC/x64/MD
+    <runtime-link>shared,<variant>debug:<search>$(openssl_root)/lib/VC/x64/MDd
+    <runtime-link>static,<variant>release:<search>$(openssl_root)/lib/VC/x64/MT
+    <runtime-link>static,<variant>debug:<search>$(openssl_root)/lib/VC/x64/MTd
     <ssl-name>libssl
     <crypto-name>libcrypto
 ;

--- a/tools/user-config.jam
+++ b/tools/user-config.jam
@@ -18,6 +18,6 @@ using openssl : :
     <runtime-link>shared,<variant>debug:<search>$(openssl_root)/lib/VC/x64/MDd
     <runtime-link>static,<variant>release:<search>$(openssl_root)/lib/VC/x64/MT
     <runtime-link>static,<variant>debug:<search>$(openssl_root)/lib/VC/x64/MTd
-    <ssl-name>libssl
-    <crypto-name>libcrypto
+    <ssl-name>libssl.lib
+    <crypto-name>libcrypto.lib
 ;

--- a/tools/user-config.jam
+++ b/tools/user-config.jam
@@ -14,10 +14,10 @@ local openssl_root = "C:/Program Files/OpenSSL" ;
 
 using openssl : :
     <include>$(openssl_root)/include
-    <runtime-link>shared,<variant>release:<search>$(openssl_root)/lib/VC/x64/MD
-    <runtime-link>shared,<variant>debug:<search>$(openssl_root)/lib/VC/x64/MDd
-    <runtime-link>static,<variant>release:<search>$(openssl_root)/lib/VC/x64/MT
-    <runtime-link>static,<variant>debug:<search>$(openssl_root)/lib/VC/x64/MTd
-    <ssl-name>libssl.lib
-    <crypto-name>libcrypto.lib
+    <runtime-link>shared,<variant>release:<search>"$(openssl_root)/lib/VC/x64/MD"
+    <runtime-link>shared,<variant>debug:<search>"$(openssl_root)/lib/VC/x64/MDd"
+    <runtime-link>static,<variant>release:<search>"$(openssl_root)/lib/VC/x64/MT"
+    <runtime-link>static,<variant>debug:<search>"$(openssl_root)/lib/VC/x64/MTd"
+    <ssl-name>libssl
+    <crypto-name>libcrypto
 ;

--- a/tools/user-config.jam
+++ b/tools/user-config.jam
@@ -14,10 +14,43 @@ local openssl_root = "C:/Program Files/OpenSSL" ;
 
 using openssl : :
     <include>$(openssl_root)/include
-    <runtime-link>shared,<variant>release:<search>"$(openssl_root)/lib/VC/x64/MD"
-    <runtime-link>shared,<variant>debug:<search>"$(openssl_root)/lib/VC/x64/MDd"
-    <runtime-link>static,<variant>release:<search>"$(openssl_root)/lib/VC/x64/MT"
-    <runtime-link>static,<variant>debug:<search>"$(openssl_root)/lib/VC/x64/MTd"
+    <search>"$(openssl_root)/lib/VC/x64/MD"
     <ssl-name>libssl
     <crypto-name>libcrypto
+    : 
+    <runtime-link>shared
+    <variant>release
 ;
+
+using openssl : :
+    <include>$(openssl_root)/include
+    <search>"$(openssl_root)/lib/VC/x64/MDd"
+    <ssl-name>libssl
+    <crypto-name>libcrypto
+    :
+    <runtime-link>shared
+    <variant>debug
+;
+
+
+using openssl : :
+    <include>$(openssl_root)/include
+    <search>"$(openssl_root)/lib/VC/x64/MT"
+    <ssl-name>libssl
+    <crypto-name>libcrypto
+    :
+    <runtime-link>static
+    <variant>release
+;
+
+
+using openssl : :
+    <include>$(openssl_root)/include
+    <search>"$(openssl_root)/lib/VC/x64/MTd"
+    <ssl-name>libssl
+    <crypto-name>libcrypto
+    :
+    <runtime-link>static
+    <variant>debug
+;
+

--- a/tools/user-config.jam
+++ b/tools/user-config.jam
@@ -1,12 +1,10 @@
 # Used on CI. This is required on Windows to make b2 find openssl
 
-import os ;
-
-local OPENSSL_ROOT = [ os.environ OPENSSL_ROOT ] ;
+local openssl_root = "C:/Program Files/OpenSSL" ;
 
 using openssl : :
-    <include>$(OPENSSL_ROOT)/include
-    <search>$(OPENSSL_ROOT)/lib
+    <include>$(openssl_root)/include
+    <search>$(openssl_root)/lib
     <ssl-name>libssl
     <crypto-name>libcrypto
 ;

--- a/tools/user-config.jam
+++ b/tools/user-config.jam
@@ -1,10 +1,19 @@
-# Used on CI. This is required on Windows to make b2 find openssl
+# Used on CI. This is required on Windows to make b2 find OpenSSL.
+#
+# Layout matches the Shining Light Productions OpenSSL installer that ships in
+# the actions/runner-images Windows 2022 image:
+#   <root>/include/                  headers
+#   <root>/lib/VC/x64/MD/*.lib       release libs (linked against /MD runtime)
+#   <root>/lib/VC/x64/MDd/*.lib      debug libs (linked against /MDd runtime)
+#
+# Conditional <search> paths route b2 to the right .lib for the variant being built.
 
 local openssl_root = "C:/Program Files/OpenSSL" ;
 
 using openssl : :
     <include>$(openssl_root)/include
-    <search>$(openssl_root)/lib
+    <variant>release:<search>$(openssl_root)/lib/VC/x64/MD
+    <variant>debug:<search>$(openssl_root)/lib/VC/x64/MDd
     <ssl-name>libssl
     <crypto-name>libcrypto
 ;

--- a/tools/user-config.jam
+++ b/tools/user-config.jam
@@ -1,14 +1,11 @@
 # Used on CI. This is required on Windows to make b2 find OpenSSL.
 #
-# Layout matches the Shining Light Productions OpenSSL installer that ships in
-# the actions/runner-images Windows 2022 image:
+# Layout matches the Shining Light Productions OpenSSL installer:
 #   <root>/include/                  headers
 #   <root>/lib/VC/x64/MD/*.lib       release libs (linked against /MD  runtime)
 #   <root>/lib/VC/x64/MDd/*.lib      debug   libs (linked against /MDd runtime)
 #   <root>/lib/VC/x64/MT/*.lib       release libs (linked against /MT  runtime)
 #   <root>/lib/VC/x64/MTd/*.lib      debug   libs (linked against /MTd runtime)
-#
-# Conditional <search> paths route b2 to the right .lib for the variant being built.
 
 local openssl_root = "C:/Program Files/OpenSSL" ;
 


### PR DESCRIPTION
Correctly sets OpenSSL paths in the B2 Windows build in GHA
Adds a check to prevent the build from succeeding in case OpenSSL is not found