### PR TITLE
Fix use two-iterator erase-remove in multiplexer::cancel to avoid UB

### DIFF
--- a/include/boost/redis/impl/multiplexer.ipp
+++ b/include/boost/redis/impl/multiplexer.ipp
@@ -58,7 +58,7 @@ void multiplexer::cancel(std::shared_ptr<elem> const& ptr)
 {
    if (ptr->is_waiting()) {
       // We can safely remove it from the queue, since it hasn't been sent yet
-      reqs_.erase(std::remove(std::begin(reqs_), std::end(reqs_), ptr));
+      reqs_.erase(std::remove(std::begin(reqs_), std::end(reqs_), ptr), std::end(reqs_));
    } else {
       // Removing the request would cause trouble when the response arrived.
       // Mark it as abandoned, so the response is discarded when it arrives


### PR DESCRIPTION
## Summary

Fix an incorrect erase-remove use in `multiplexer::cancel`.

The current code calls the single-iterator overload of `deque::erase` on the result of `std::remove`:

```cpp
reqs_.erase(std::remove(std::begin(reqs_), std::end(reqs_), ptr));
```

If `ptr` is not present in `reqs_`, `std::remove` returns `end()`, making this `erase(end())`, which is undefined behavior.

This can happen when a request is cancelled after it has already been removed from the queue, for example during connection teardown or reconnect handling.

The fix is to use the normal two-iterator erase-remove form:

```cpp
reqs_.erase(std::remove(std::begin(reqs_), std::end(reqs_), ptr), std::end(reqs_));
```

This also matches the two-iterator `erase(first, last)` form used by the other queue-trimming functions in this file (`cancel_waiting`, `cancel_on_conn_lost`, `release_push_requests`).

## Testing

Observed with `-D_GLIBCXX_DEBUG`, where the invalid `erase(end())` path aborts with a past-the-end iterator error.